### PR TITLE
Fixed foreign key support for django 1.4 (backward compatible)

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -76,7 +76,7 @@ class HistoricalRecords(object):
                 fk = True
             else:
                 fk = False
-            
+
             # The historical instance should not change creation/modification timestamps.
             field.auto_now = False
             field.auto_now_add = False
@@ -88,9 +88,8 @@ class HistoricalRecords(object):
                 field._unique = False
                 field.db_index = True
             if fk:
-                fields[field.name+"_id"] = field
-            else:
-                fields[field.name] = field
+                field.name = field.name + "_id"
+            fields[field.name] = field
 
         return fields
 


### PR DESCRIPTION
As shown in issue #2, foreign keys for simple history models break with django 1.4. The proposed pull request #2 works for django 1.4 but is not backward compatible. I'm submitting this new pull request that addresses the same issue and works for django 1.2, 1.3 and 1.4.
