### PR TITLE
Fix for issue #7 (app_label issue)

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -144,6 +144,7 @@ class HistoricalRecords(object):
         """
         return {
             'ordering': ('-history_date', '-history_id'),
+            'app_label': model._meta.app_label,
         }
 
     def post_save(self, instance, created, **kwargs):


### PR DESCRIPTION
Always use the same app_label on the historical record model.
