### PR TITLE
allow history table to be formatted correctly when used with bootstrap

### DIFF
--- a/simple_history/templates/simple_history/object_history.html
+++ b/simple_history/templates/simple_history/object_history.html
@@ -10,7 +10,7 @@
 
     <div class="module">
       {% if action_list %}
-        <table id="change-history">
+        <table id="change-history" class="table table-bordered table-striped">
           <thead>
             <tr>
               <th scope="col">{% trans 'Object' %}</th>


### PR DESCRIPTION
allow history table to be formatted correctly when used
with bootstrap (e.g. django-admin-bootstrap)
