### PR TITLE
Fix for documentation of user who changed a model

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -87,5 +87,5 @@ referencing the ``changed_by`` field:
             return self.changed_by
 
         @_history_user.setter
-        def _history_user_setter(self, value):
+        def _history_user(self, value):
             self.changed_by = value


### PR DESCRIPTION
In the example code for "Recording Which User Changed a Model" the property getter and setter have different names, but according to the python documentation (http://docs.python.org/2/library/functions.html#property) a property setter must have the same name as the getter.
