### PR TITLE
Generated model base class override

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -89,3 +89,31 @@ referencing the ``changed_by`` field:
         @_history_user.setter
         def _history_user_setter(self, value):
             self.changed_by = value
+
+
+Change Base Class of HistoricalRecord Models
+--------------------------------------------
+
+To change the auto-generated HistoricalRecord models base class from
+``models.Model``, pass in the class to ``base_class``.
+
+This is useful in cases where you're using the base class of a model for
+database routing. Just be aware that your base model should not be adding
+fields through model inheritance.
+
+.. code-block:: python
+
+    from django.db import models
+    from simple_history.models import HistoricalRecords
+
+    class RoutableModel(models.Model):
+        class Meta:
+            abstract = True
+
+
+    class Poll(models.Model):
+        question = models.CharField(max_length=200)
+        pub_date = models.DateTimeField('date published')
+        changed_by = models.ForeignKey('auth.User')
+        history = HistoricalRecords(base_class=RoutableModel)
+

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -35,8 +35,9 @@ registered_models = {}
 
 
 class HistoricalRecords(object):
-    def __init__(self, verbose_name=None):
+    def __init__(self, verbose_name=None, base_class=None):
         self.user_set_verbose_name = verbose_name
+        self.base_class = base_class
 
     def contribute_to_class(self, cls, name):
         self.manager_name = name
@@ -98,8 +99,11 @@ class HistoricalRecords(object):
         attrs.update(Meta=type(str('Meta'), (), self.get_meta_options(model)))
         name = 'Historical%s' % model._meta.object_name
         registered_models[model._meta.db_table] = model
+        base_class = models.Model
+        if self.base_class is not None:
+            base_class = self.base_class
         return python_2_unicode_compatible(
-            type(str(name), (models.Model,), attrs))
+            type(str(name), (base_class,), attrs))
 
     def copy_fields(self, model):
         """


### PR DESCRIPTION
This is lacking some tests but shows the basic idea of allowing the
generated model to override the base class of that model (e.g. MyModel as opposed to django.db.models.Model).
