### PR TITLE
Update advanced.rst

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -87,5 +87,5 @@ referencing the ``changed_by`` field:
             return self.changed_by
 
         @_history_user.setter
-        def _history_user_setter(self, value):
+        def _history_user(self, value):
             self.changed_by = value


### PR DESCRIPTION
property.setter requires the function name be the same as property.getter when decorating the setter function.
