### PR TITLE
Revert the addition of my nickname to AUTHORS.rst, as my realname is already included

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,7 +7,6 @@ Authors
 - Damien Nozay
 - Daniel Levy
 - Daniel Roschka
-- Dunedan
 - George Vilches
 - Hamish Downer
 - Joao Pedro Francese


### PR DESCRIPTION
#75 already included a change to `AUTHORS.rst`, adding my realname ("Daniel Roschka"). In 0fe93d8874317d7584fd2aacb7b0215cfe153983 you also added my nickname ("Dunedan"), resulting in two entries for me in `AUTHORS.rst`. This commit reverts 0fe93d8874317d7584fd2aacb7b0215cfe153983 so that I only appear once in `AUTHORS.rst`.
