### PR TITLE
Fix Python 3.2 tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 import simple_history
 
 setup(
@@ -13,7 +13,7 @@ setup(
     author_email='corey@qr7.com',
     maintainer='Trey Hunner',
     url='https://github.com/treyhunner/django-simple-history',
-    packages=find_packages(),
+    packages=["simple_history"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Framework :: Django",


### PR DESCRIPTION
For some reason coverage gets lost in the ``find_packages` function, only using Python 3.2. I still have no clue why.
