### PR TITLE
Fix deprecation error for Django 1.8

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -37,9 +37,9 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         admin_site = self.admin_site
         opts = self.model._meta
         try:
-            info = opts.app_label, opts.module_name
-        except AttributeError:
             info = opts.app_label, opts.model_name
+        except AttributeError:
+            info = opts.app_label, opts.module_name
         history_urls = patterns(
             "",
             url("^([^/]+)/history/([^/]+)/$",
@@ -128,9 +128,9 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         media = self.media + admin_form.media
 
         try:
-            model_name = original_opts.module_name
-        except AttributeError:
             model_name = original_opts.model_name
+        except AttributeError:
+            model_name = original_opts.module_name
         url_triplet = self.admin_site.name, original_opts.app_label, model_name
         content_type_id = ContentType.objects.get_for_model(self.model).id
         context = {

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -165,9 +165,9 @@ class HistoricalRecords(object):
             """URL for this change in the default admin site."""
             opts = model._meta
             try:
-                app_label, model_name = opts.app_label, opts.module_name
-            except AttributeError:
                 app_label, model_name = opts.app_label, opts.model_name
+            except AttributeError:
+                app_label, model_name = opts.app_label, opts.module_name
             return ('%s:%s_%s_simple_history' %
                     (admin.site.name, app_label, model_name),
                     [getattr(self, opts.pk.attname), self.history_id])


### PR DESCRIPTION
Switch order of checking for model_name vs module_name to stop deprecation warning
