### PR TITLE
Do not merge: Fix #140 - Don't include OrderWrt proxy fields

### DIFF
--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -217,3 +217,18 @@ class UnicodeVerboseName(models.Model):
 class CustomFKError(models.Model):
     fk = models.ForeignKey(SecondLevelInheritedModel)
     history = HistoricalRecords()
+
+
+class Series(models.Model):
+    """A series of works, like a trilogy of books."""
+    name = models.CharField(max_length=100)
+    author = models.CharField(max_length=100)
+
+
+class SeriesWork(models.Model):
+    series = models.ForeignKey('Series', related_name='works')
+    title = models.CharField(max_length=100)
+    history = HistoricalRecords()
+
+    class Meta:
+        order_with_respect_to = 'series'

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -24,7 +24,7 @@ from ..models import (
     Person, FileModel, Document, Book, HistoricalPoll, Library, State,
     AbstractBase, ConcreteAttr, ConcreteUtil, SelfFK, Temperature, WaterLevel,
     ExternalModel1, ExternalModel3, UnicodeVerboseName, HistoricalChoice,
-    HistoricalState, HistoricalCustomFKError
+    HistoricalState, HistoricalCustomFKError, Series
 )
 from ..external.models import ExternalModel2, ExternalModel4
 
@@ -280,6 +280,17 @@ class HistoricalRecordsTest(TestCase):
         l.save()
         self.assertEqual('historical quiet please',
                          l.history.get()._meta.verbose_name)
+
+    def test_ordered_with_respect_to_omitted(self):
+        s = Series.objects.create(
+            name="The Hitchhiker's Guide to the Galaxy Trilogy",
+            author="Douglas Adams")
+        w4 = s.works.create(title="So Long, and Thanks for All the Fish")
+        history = w4.history.get()
+
+        self.assertTrue(hasattr(w4, '_order'))
+        self.assertFalse(hasattr(history, '_order'))
+        self.assertIsNone(history.history_object._order)
 
 
 class RegisterTest(TestCase):


### PR DESCRIPTION
An OrderWrt field named _order is added when the Meta.order_with_respect_to option is used on the model.  This code drops this field from the historical model, and doesn't copy it when creating a historical record.

See #140 for more information.
