### PR TITLE
Fix #140 - Convert OrderWrt to IntegerField

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -8,6 +8,7 @@ except ImportError:
     apps = None
 from django.db import models, router
 from django.db.models import loading
+from django.db.models.fields.proxy import OrderWrt
 from django.db.models.fields.related import RelatedField
 from django.db.models.related import RelatedObject
 from django.conf import settings
@@ -135,6 +136,9 @@ class HistoricalRecords(object):
                 field.rel.related_name = '+'
                 field.null = True
                 field.blank = True
+            if isinstance(field, OrderWrt):
+                # OrderWrt is a proxy field, switch to a plain IntegerField
+                field.__class__ = models.IntegerField
             transform_field(field)
             fields[field.name] = field
         return fields

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -217,3 +217,18 @@ class UnicodeVerboseName(models.Model):
 class CustomFKError(models.Model):
     fk = models.ForeignKey(SecondLevelInheritedModel)
     history = HistoricalRecords()
+
+
+class Series(models.Model):
+    """A series of works, like a trilogy of books."""
+    name = models.CharField(max_length=100)
+    author = models.CharField(max_length=100)
+
+
+class SeriesWork(models.Model):
+    series = models.ForeignKey('Series', related_name='works')
+    title = models.CharField(max_length=100)
+    history = HistoricalRecords()
+
+    class Meta:
+        order_with_respect_to = 'series'


### PR DESCRIPTION
An `OrderWrt` field named `_order` is added when the `Meta.order_with_respect_to option` is used on the model.  This code:
- Switches it to an `IntegerField` in the historical model
- Ignores changes in ordering (done via update, so `save()` signals are not generated)
- Restores the old value when loading from a `history_object`, which may
  result in non-deterministic ordering until `set_RELATED_order()` is
  called again.

The ordering could be 'frozen' by calling `set_RELATED_order(get_RELATED_order())`, but it's not clear that would be better, especially considering multiple restores from history.

See #140 for the full discussion, and PR #141 for an aborted attempt to drop the ordering field in the history model.
