### PR TITLE
Indicate non-coverage areas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ django-simple-history
 
 django-simple-history stores Django model state on every create/update/delete.
 
-This app requires Django 1.4 or greater and Python 2.6 or greater.
+This app requires Django 1.4.2 or greater and Python 2.6 or greater.
 
 Getting Help
 ------------

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -11,15 +11,12 @@ from django.contrib.admin.util import unquote
 from django.utils.text import capfirst
 from django.utils.html import mark_safe
 from django.utils.translation import ugettext as _
-try:
-    from django.utils.encoding import force_text
-except ImportError:  # django 1.3 compatibility
-    from django.utils.encoding import force_unicode as force_text
+from django.utils.encoding import force_text
 from django.conf import settings
 
 try:
     USER_NATURAL_KEY = settings.AUTH_USER_MODEL
-except AttributeError:
+except AttributeError:  # Django < 1.5
     USER_NATURAL_KEY = "auth.User"
 USER_NATURAL_KEY = tuple(key.lower() for key in USER_NATURAL_KEY.split('.', 1))
 
@@ -35,7 +32,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         opts = self.model._meta
         try:
             info = opts.app_label, opts.model_name
-        except AttributeError:
+        except AttributeError:  # Django < 1.7
             info = opts.app_label, opts.module_name
         history_urls = patterns(
             "",
@@ -115,7 +112,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
 
         try:
             model_name = original_opts.model_name
-        except AttributeError:
+        except AttributeError:  # Django < 1.7
             model_name = original_opts.module_name
         url_triplet = self.admin_site.name, original_opts.app_label, model_name
         context = {

--- a/simple_history/management/commands/_populate_utils.py
+++ b/simple_history/management/commands/_populate_utils.py
@@ -1,9 +1,4 @@
-try:
-    from django.utils.timezone import now
-except ImportError:     # pragma: no cover
-    from datetime import datetime
-    now = datetime.now
-from django.db import transaction
+from django.utils.timezone import now
 
 
 class NotHistorical(TypeError):
@@ -29,10 +24,4 @@ def bulk_history_create(model, history_model):
             **dict((field.attname, getattr(instance, field.attname))
                    for field in instance._meta.fields)
         ) for instance in model.objects.all()]
-    try:
-        history_model.objects.bulk_create(historical_instances)
-    except AttributeError:  # pragma: no cover
-        # bulk_create was added in Django 1.4, handle legacy versions
-        with transaction.commit_on_success():
-            for instance in historical_instances:
-                instance.save()
+    history_model.objects.bulk_create(historical_instances)

--- a/simple_history/management/commands/populate_history.py
+++ b/simple_history/management/commands/populate_history.py
@@ -75,8 +75,7 @@ class Command(BaseCommand):
         else:
             try:
                 model = get_model(app_label, model)
-                # Django 1.7 raises a LookupError
-            except LookupError:     # pragma: no cover
+            except LookupError:  # Django >= 1.7
                 model = None
         if not model:
             raise ValueError(self.MODEL_NOT_FOUND +

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -22,7 +22,7 @@ class HistoryManager(models.Manager):
     def get_super_queryset(self):
         try:
             return super(HistoryManager, self).get_queryset()
-        except AttributeError:
+        except AttributeError:  # Django < 1.6
             return super(HistoryManager, self).get_query_set()
 
     def get_queryset(self):

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -3,8 +3,8 @@ from __future__ import unicode_literals
 import threading
 import copy
 try:
-    from django.apps import apps  # Django >= 1.7
-except ImportError:
+    from django.apps import apps
+except ImportError:  # Django < 1.7
     apps = None
 from django.db import models, router
 from django.db.models import loading
@@ -15,21 +15,14 @@ from django.conf import settings
 from django.contrib import admin
 from django.utils import importlib, six
 from django.utils.encoding import python_2_unicode_compatible
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_unicode as smart_text
-try:
-    from django.utils.timezone import now
-except ImportError:
-    from datetime import datetime
-    now = datetime.now
+from django.utils.encoding import smart_text
+from django.utils.timezone import now
 from django.utils.translation import string_concat
 try:
     from south.modelsinspector import add_introspection_rules
-except ImportError:
+except ImportError:  # south not present
     pass
-else:
+else:  # south configuration for CustomForeignKeyField
     add_introspection_rules(
         [], ["^simple_history.models.CustomForeignKeyField"])
 from .manager import HistoryDescriptor
@@ -100,7 +93,7 @@ class HistoricalRecords(object):
             # registered under different app
             attrs['__module__'] = self.module
         elif app_module != self.module:
-            if apps is None:
+            if apps is None:  # Django < 1.7
                 # has meta options with app_label
                 app = loading.get_app(model._meta.app_label)
                 attrs['__module__'] = app.__name__  # full dotted name
@@ -154,7 +147,7 @@ class HistoricalRecords(object):
             opts = model._meta
             try:
                 app_label, model_name = opts.app_label, opts.model_name
-            except AttributeError:
+            except AttributeError:  # Django < 1.7
                 app_label, model_name = opts.app_label, opts.module_name
             return ('%s:%s_%s_simple_history' %
                     (admin.site.name, app_label, model_name),


### PR DESCRIPTION
I marked the lines we don't plan on hitting in the primary test run (Django 1.7 on Python 3.4) with the 'no cover' coverage pragma and marked the reason for the compatability: The version of Django if that was the reason, or a short description if it was something else.

I also removed the compatibility we had for Django versions older than 1.4 that did not have the timezone util module.
