### PR TITLE
Do NOT CASCADE delete the history elements when a user gets deleted.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Authors
 - Micah Denbraver
 - Rajesh Pappula
 - Ross Lote
+- Steven Klass
 - Trey Hunner
 - Ulysses Vilela
 - vnagendra

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+1.5.x (YYYY-MM-DD)
+------------------
+- Do NOT delete the history elements when a user is deleted.
+
 1.5.3 (2014-11-18)
 ------------------
 - Fix migrations while using ``order_with_respsect_to`` (gh-140)

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -167,7 +167,8 @@ class HistoricalRecords(object):
             'history_id': models.AutoField(primary_key=True),
             'history_date': models.DateTimeField(),
             'history_user': models.ForeignKey(
-                user_model, null=True, related_name=self.user_related_name),
+                user_model, null=True, related_name=self.user_related_name,
+                on_delete=models.SET_NULL),
             'history_type': models.CharField(max_length=1, choices=(
                 ('+', 'Created'),
                 ('~', 'Changed'),

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -219,3 +219,19 @@ class AdminSiteTest(WebTest):
         self.app.get(history_url)
         change_url = get_history_url(state, 0, site="other_admin")
         self.app.get(change_url)
+
+    def test_deleteting_user(self):
+        """Test deletes of a user does not cascade delete the history"""
+        self.login()
+        poll = Poll(question="why?", pub_date=today)
+        poll._history_user = self.user
+        poll.save()
+
+        historical_poll = poll.history.all()[0]
+        self.assertEqual(historical_poll.history_user, self.user)
+
+        self.user.delete()
+
+        historical_poll = poll.history.all()[0]
+        self.assertEqual(historical_poll.history_user, None)
+


### PR DESCRIPTION
Simply set the User field to None.  Fixes #149 
