### PR TITLE
Add index on `history_date` field to improve performance of `get_next_record()` and `get_prev_record()` methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 - Fix `model_to_dict` to detect changes in a parent model when using
   `inherit=True` (backwards-incompatible for users who were directly
   using previous version) (gh-576)
+- Added index on ``history_date`` column
 
 2.7.3 (2019-07-15)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -412,7 +412,7 @@ class HistoricalRecords(object):
 
         extra_fields = {
             "history_id": self._get_history_id_field(),
-            "history_date": models.DateTimeField(),
+            "history_date": models.DateTimeField(db_index=True),
             "history_change_reason": self._get_history_change_reason_field(),
             "history_type": models.CharField(
                 max_length=1,


### PR DESCRIPTION
## Description
Calling methods `get_next_record()` and `get_prev_record()`  https://github.com/treyhunner/django-simple-history/blob/master/simple_history/models.py#L391 creates a heavy load on database without indexes (full scan)

## Related Issue
https://github.com/treyhunner/django-simple-history/issues/565

## How Has This Been Tested?
Create new migration after changes and test sql queries time

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [x ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
