### PR TITLE
Remove db constraint on historical user to prevent IntegrityError 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -60,6 +60,7 @@ Authors
 - Jonathan Sanchez
 - Jonathan Zvesper (`zvesp <https://github.com/zvesp>`_)
 - Josh Fyne
+- Keith Hackbarth
 - Kevin Foster
 - Klaas van Schelven
 - Kris Neuharth

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 Changes
 =======
 2.10.1 (2020-06-16)
+- added ``user_db_constraint`` param to history to avoid circular reference on delete (gh-676)
 - added ``clean_old_history`` management command (gh-675)
 
 2.10.0 (2020-04-27)

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -67,7 +67,6 @@ class HistoricalRecords(object):
         verbose_name=None,
         bases=(models.Model,),
         user_related_name="+",
-        user_db_constraint=True,
         table_name=None,
         inherit=False,
         excluded_fields=None,
@@ -83,6 +82,7 @@ class HistoricalRecords(object):
         history_user_setter=_history_user_setter,
         related_name=None,
         use_base_model_db=False,
+        user_db_constraint=True,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -67,6 +67,7 @@ class HistoricalRecords(object):
         verbose_name=None,
         bases=(models.Model,),
         user_related_name="+",
+        user_db_constraint=True,
         table_name=None,
         inherit=False,
         excluded_fields=None,
@@ -85,6 +86,7 @@ class HistoricalRecords(object):
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
+        self.user_db_constraint = user_db_constraint
         self.table_name = table_name
         self.inherit = inherit
         self.history_id_field = history_id_field
@@ -342,6 +344,7 @@ class HistoricalRecords(object):
                     null=True,
                     related_name=self.user_related_name,
                     on_delete=models.SET_NULL,
+                    db_constraint=self.user_db_constraint,
                 )
             }
 

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -214,7 +214,10 @@ class Document(models.Model):
 
     @property
     def _history_user(self):
-        return self.changed_by
+        try:
+            return self.changed_by
+        except User.DoesNotExist:
+            return None
 
 
 class Paper(Document):


### PR DESCRIPTION
Add `db_constraint=False` to the history_user field

## Description
There's a known issue (see link below) where if the user_model has `history = HistoricalRecords` tracked on it, then an IntegrityError is raised when trying to delete that user. I believe this is because of the order in which Django deletes essentially causes a circular-referencing error within the database.

This change simply removes the db_constraint from this field. Thus, solving the problem. Multiple other users have raised this as the solution in the linked issue.

I was originally hesitate about use db_constraint=False and was considering making it optional, but noticed that this paradigm is already leveraged multiple times in this codebase.

## Related Issue
https://github.com/jazzband/django-simple-history/issues/391

## How Has This Been Tested?
Added a test to the test suite that covers the bug found in #391. 
Also, it seems like myself (as well as multiple other users) are already running this fork in their own production environments without issue.

## Screenshots (if appropriate):
n/a

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
