### PR TITLE
Get default user for bulk ops from middleware

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,12 @@
 Changes
 =======
-2.10.1 (2020-06-16)
-- added ``user_db_constraint`` param to history to avoid circular reference on delete (gh-676)
-- added ``clean_old_history`` management command (gh-675)
+
+Unreleased
+----------
+- Added ``clean_old_history`` management command (gh-675)
+- Added ``user_db_constraint`` param to history to avoid circular reference on delete (gh-676)
+- Leverages ``get_user`` from ``HistoricalRecords`` in order to set a fallback user on
+  bulk update and bulk create (gh-677)
 
 2.10.0 (2020-04-27)
 -------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -422,11 +422,9 @@ class HistoricalRecords(object):
                 .last()
             )
 
-        def __init__(instance, *args, **kwargs):
-            """Sets the user from get_user method on instance when initializing"""
-            super(type(instance), instance).__init__(*args, **kwargs)
-            if not instance.history_user_id and instance._adding:
-                instance.history_user = self.get_history_user(instance)
+        def get_default_history_user(instance):
+            """Returns the user specified by the `get_user` method for use when manually creating an historical object"""
+            return self.get_history_user(instance)
 
         extra_fields = {
             "history_id": self._get_history_id_field(),
@@ -447,7 +445,7 @@ class HistoricalRecords(object):
             "__str__": lambda self: "{} as of {}".format(
                 self.history_object, self.history_date
             ),
-            "__init__": __init__
+            "get_default_history_user": staticmethod(get_default_history_user),
         }
 
         extra_fields.update(self._get_history_related_field(model))

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -423,7 +423,10 @@ class HistoricalRecords(object):
             )
 
         def get_default_history_user(instance):
-            """Returns the user specified by the `get_user` method for use when manually creating an historical object"""
+            """
+            Returns the user specified by `get_user` method for manually creating
+            historical objects
+            """
             return self.get_history_user(instance)
 
         extra_fields = {

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -422,6 +422,12 @@ class HistoricalRecords(object):
                 .last()
             )
 
+        def __init__(instance, *args, **kwargs):
+            """Sets the user from get_user method on instance when initializing"""
+            super(type(instance), instance).__init__(*args, **kwargs)
+            if not instance.history_user_id and instance._adding:
+                instance.history_user = self.get_history_user(instance)
+
         extra_fields = {
             "history_id": self._get_history_id_field(),
             "history_date": models.DateTimeField(),
@@ -441,6 +447,7 @@ class HistoricalRecords(object):
             "__str__": lambda self: "{} as of {}".format(
                 self.history_object, self.history_date
             ),
+            "__init__": __init__
         }
 
         extra_fields.update(self._get_history_related_field(model))

--- a/simple_history/tests/tests/test_middleware.py
+++ b/simple_history/tests/tests/test_middleware.py
@@ -176,9 +176,7 @@ class MiddlewareBulkOpsTest(TestCase):
 
         self.assertListEqual([ph.history_user_id for ph in poll_history], [None, None])
 
-    def test_request_user_is_overwritten_by_default_user_on_bulk_create_view_when_logged_in(
-        self,
-    ):
+    def test_request_user_is_overwritten_by_default_user_on_bulk_create_view(self,):
         self.client.force_login(self.user)
         self.client.post(reverse("poll-bulk-create-with-default-user"), data={})
 

--- a/simple_history/tests/tests/test_middleware.py
+++ b/simple_history/tests/tests/test_middleware.py
@@ -176,7 +176,9 @@ class MiddlewareBulkOpsTest(TestCase):
 
         self.assertListEqual([ph.history_user_id for ph in poll_history], [None, None])
 
-    def test_request_user_is_overwritten_by_default_user_on_bulk_create_view_when_logged_in(self):
+    def test_request_user_is_overwritten_by_default_user_on_bulk_create_view_when_logged_in(
+        self,
+    ):
         self.client.force_login(self.user)
         self.client.post(reverse("poll-bulk-create-with-default-user"), data={})
 
@@ -191,7 +193,9 @@ class MiddlewareBulkOpsTest(TestCase):
     def test_user_is_set_on_bulk_update_view_when_logged_in(self):
         self.client.force_login(self.user)
         poll_1 = Poll.objects.create(question="Test question 1", pub_date=date.today())
-        poll_2 = Poll.objects.create(question="Test question 2", pub_date=date(2020, 1, 1))
+        poll_2 = Poll.objects.create(
+            question="Test question 2", pub_date=date(2020, 1, 1)
+        )
 
         self.client.post(reverse("poll-bulk-update"), data={})
 
@@ -200,12 +204,18 @@ class MiddlewareBulkOpsTest(TestCase):
 
         self.assertEqual("1", poll_1.history.latest("history_date").question)
         self.assertEqual("0", poll_2.history.latest("history_date").question)
-        self.assertEqual(self.user.id, poll_1.history.latest("history_date").history_user_id)
-        self.assertEqual(self.user.id, poll_2.history.latest("history_date").history_user_id)
+        self.assertEqual(
+            self.user.id, poll_1.history.latest("history_date").history_user_id
+        )
+        self.assertEqual(
+            self.user.id, poll_2.history.latest("history_date").history_user_id
+        )
 
     def test_user_is_not_set_on_bulk_update_view_when_not_logged_in(self):
         poll_1 = Poll.objects.create(question="Test question 1", pub_date=date.today())
-        poll_2 = Poll.objects.create(question="Test question 2", pub_date=date(2020, 1, 1))
+        poll_2 = Poll.objects.create(
+            question="Test question 2", pub_date=date(2020, 1, 1)
+        )
 
         self.client.post(reverse("poll-bulk-update"), data={})
 
@@ -219,4 +229,6 @@ class MiddlewareBulkOpsTest(TestCase):
         self.client.post(reverse("poll-bulk-update-with-default-user"), data={})
 
         self.assertIsNotNone(poll.history.latest("history_date").history_user_id)
-        self.assertNotEqual(self.user.id, poll.history.latest("history_date").history_user_id)
+        self.assertNotEqual(
+            self.user.id, poll.history.latest("history_date").history_user_id
+        )

--- a/simple_history/tests/tests/test_middleware.py
+++ b/simple_history/tests/tests/test_middleware.py
@@ -145,3 +145,78 @@ class MiddlewareTest(TestCase):
         history = bucket_datas.first().history.all()
 
         self.assertListEqual([h.history_user_id for h in history], [member1.id])
+
+
+@override_settings(**middleware_override_settings)
+class MiddlewareBulkOpsTest(TestCase):
+    def setUp(self):
+        self.user = CustomUser.objects.create_superuser(
+            "user_login", "u@example.com", "pass"
+        )
+
+    def test_user_is_set_on_bulk_create_view_when_logged_in(self):
+        self.client.force_login(self.user)
+        self.client.post(reverse("poll-bulk-create"), data={})
+        polls = Poll.objects.all()
+        self.assertEqual(len(polls), 2)
+
+        poll_history = Poll.history.all()
+
+        self.assertCountEqual(
+            [ph.history_user_id for ph in poll_history], [self.user.id, self.user.id]
+        )
+
+    def test_user_is_not_set_on_bulk_create_view_not_logged_in(self):
+        self.client.post(reverse("poll-bulk-create"), data={})
+
+        polls = Poll.objects.all()
+        self.assertEqual(polls.count(), 2)
+
+        poll_history = Poll.history.all()
+
+        self.assertListEqual([ph.history_user_id for ph in poll_history], [None, None])
+
+    def test_request_user_is_overwritten_by_default_user_on_bulk_create_view_when_logged_in(self):
+        self.client.force_login(self.user)
+        self.client.post(reverse("poll-bulk-create-with-default-user"), data={})
+
+        polls = Poll.objects.all()
+        self.assertEqual(len(polls), 2)
+
+        poll_history = Poll.history.all()
+
+        self.assertFalse(any(ph.history_user_id == self.user.id for ph in poll_history))
+        self.assertFalse(any(ph.history_user_id is None for ph in poll_history))
+
+    def test_user_is_set_on_bulk_update_view_when_logged_in(self):
+        self.client.force_login(self.user)
+        poll_1 = Poll.objects.create(question="Test question 1", pub_date=date.today())
+        poll_2 = Poll.objects.create(question="Test question 2", pub_date=date(2020, 1, 1))
+
+        self.client.post(reverse("poll-bulk-update"), data={})
+
+        polls = Poll.objects.all()
+        self.assertEqual(2, len(polls))
+
+        self.assertEqual("1", poll_1.history.latest("history_date").question)
+        self.assertEqual("0", poll_2.history.latest("history_date").question)
+        self.assertEqual(self.user.id, poll_1.history.latest("history_date").history_user_id)
+        self.assertEqual(self.user.id, poll_2.history.latest("history_date").history_user_id)
+
+    def test_user_is_not_set_on_bulk_update_view_when_not_logged_in(self):
+        poll_1 = Poll.objects.create(question="Test question 1", pub_date=date.today())
+        poll_2 = Poll.objects.create(question="Test question 2", pub_date=date(2020, 1, 1))
+
+        self.client.post(reverse("poll-bulk-update"), data={})
+
+        self.assertIsNone(poll_1.history.latest("history_date").history_user_id)
+        self.assertIsNone(poll_2.history.latest("history_date").history_user_id)
+
+    def test_request_user_is_overwritten_by_default_user_on_bulk_update(self):
+        self.client.force_login(self.user)
+        poll = Poll.objects.create(pub_date=date(2020, 1, 1), question="123")
+
+        self.client.post(reverse("poll-bulk-update-with-default-user"), data={})
+
+        self.assertIsNotNone(poll.history.latest("history_date").history_user_id)
+        self.assertNotEqual(self.user.id, poll.history.latest("history_date").history_user_id)

--- a/simple_history/tests/tests/test_middleware.py
+++ b/simple_history/tests/tests/test_middleware.py
@@ -1,5 +1,7 @@
 from datetime import date
+from unittest import skipIf
 
+import django
 from django.test import TestCase, override_settings
 from django.urls import reverse
 
@@ -188,6 +190,7 @@ class MiddlewareBulkOpsTest(TestCase):
         self.assertFalse(any(ph.history_user_id == self.user.id for ph in poll_history))
         self.assertFalse(any(ph.history_user_id is None for ph in poll_history))
 
+    @skipIf(django.VERSION < (2, 2,), reason="bulk_update does not exist before 2.2")
     def test_user_is_set_on_bulk_update_view_when_logged_in(self):
         self.client.force_login(self.user)
         poll_1 = Poll.objects.create(question="Test question 1", pub_date=date.today())
@@ -209,6 +212,7 @@ class MiddlewareBulkOpsTest(TestCase):
             self.user.id, poll_2.history.latest("history_date").history_user_id
         )
 
+    @skipIf(django.VERSION < (2, 2,), reason="bulk_update does not exist before 2.2")
     def test_user_is_not_set_on_bulk_update_view_when_not_logged_in(self):
         poll_1 = Poll.objects.create(question="Test question 1", pub_date=date.today())
         poll_2 = Poll.objects.create(
@@ -220,6 +224,7 @@ class MiddlewareBulkOpsTest(TestCase):
         self.assertIsNone(poll_1.history.latest("history_date").history_user_id)
         self.assertIsNone(poll_2.history.latest("history_date").history_user_id)
 
+    @skipIf(django.VERSION < (2, 2,), reason="bulk_update does not exist before 2.2")
     def test_request_user_is_overwritten_by_default_user_on_bulk_update(self):
         self.client.force_login(self.user)
         poll = Poll.objects.create(pub_date=date(2020, 1, 1), question="123")

--- a/simple_history/tests/urls.py
+++ b/simple_history/tests/urls.py
@@ -12,6 +12,10 @@ from simple_history.tests.view import (
     PollList,
     PollUpdate,
     PollWithHistoricalIPAddressCreate,
+    PollBulkCreateView,
+    PollBulkCreateWithDefaultUserView,
+    PollBulkUpdateView,
+    PollBulkUpdateWithDefaultUserView,
 )
 from . import other_admin
 
@@ -40,4 +44,16 @@ urlpatterns = [
     url(r"^poll/(?P<pk>[0-9]+)/delete/$", PollDelete.as_view(), name="poll-delete"),
     url(r"^polls/(?P<pk>[0-9]+)/$", PollDetail.as_view(), name="poll-detail"),
     url(r"^polls/$", PollList.as_view(), name="poll-list"),
+    url(r"^polls-bulk-create/$", PollBulkCreateView.as_view(), name="poll-bulk-create"),
+    url(
+        r"^polls-bulk-create-default-user/$",
+        PollBulkCreateWithDefaultUserView.as_view(),
+        name="poll-bulk-create-with-default-user",
+    ),
+    url(r"^polls-bulk-update/$", PollBulkUpdateView.as_view(), name="poll-bulk-update"),
+    url(
+        r"^polls-bulk-update-default-user/$",
+        PollBulkUpdateWithDefaultUserView.as_view(),
+        name="poll-bulk-update-with-default-user",
+    ),
 ]

--- a/simple_history/tests/view.py
+++ b/simple_history/tests/view.py
@@ -1,4 +1,8 @@
+from datetime import date
+
+from django.http import HttpResponse
 from django.urls import reverse_lazy
+from django.views import View
 from django.views.generic import (
     CreateView,
     DeleteView,
@@ -7,16 +11,69 @@ from django.views.generic import (
     UpdateView,
 )
 
+from simple_history.tests.custom_user.models import CustomUser
 from simple_history.tests.models import (
     BucketDataRegisterRequestUser,
     Poll,
     PollWithHistoricalIPAddress,
 )
+from simple_history.utils import bulk_create_with_history, bulk_update_with_history
 
 
 class PollCreate(CreateView):
     model = Poll
     fields = ["question", "pub_date"]
+
+
+class PollBulkCreateView(View):
+    def post(self, request, *args, **kwargs):
+        poll_info_list = [
+            {"question": "1", "pub_date": date(2020, 1, 1)},
+            {"question": "2", "pub_date": date(2020, 1, 2)},
+        ]
+        polls_to_create = [Poll(**poll_info) for poll_info in poll_info_list]
+        bulk_create_with_history(polls_to_create, Poll)
+        return HttpResponse(status=200)
+
+
+class PollBulkCreateWithDefaultUserView(View):
+    def post(self, request, *args, **kwargs):
+        default_user = CustomUser.objects.create_superuser(
+            "test_user", "test_user@example.com", "pass"
+        )
+        # Bulk create objects with history
+        poll_info_list = [
+            {"question": "1", "pub_date": date(2020, 1, 1)},
+            {"question": "2", "pub_date": date(2020, 1, 2)},
+        ]
+        polls_to_create = [Poll(**poll_info) for poll_info in poll_info_list]
+        bulk_create_with_history(polls_to_create, Poll, default_user=default_user)
+        return HttpResponse(status=200)
+
+
+class PollBulkUpdateView(View):
+    def post(self, request, *args, **kwargs):
+        polls = Poll.objects.order_by("pub_date")
+        for i, poll in enumerate(polls):
+            poll.question = str(i)
+
+        bulk_update_with_history(polls, fields=["question"], model=Poll)
+        return HttpResponse(status=201)
+
+
+class PollBulkUpdateWithDefaultUserView(View):
+    def post(self, request, *args, **kwargs):
+        default_user = CustomUser.objects.create_superuser(
+            "test_user", "test_user@example.com", "pass"
+        )
+        polls = Poll.objects.all()
+        for i, poll in enumerate(polls):
+            poll.question = str(i)
+
+        bulk_update_with_history(
+            polls, fields=["question"], model=Poll, default_user=default_user
+        )
+        return HttpResponse(status=201)
 
 
 class PollWithHistoricalIPAddressCreate(CreateView):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bulk utility operations such as `bulk_create_with_history` and `bulk_update_with_history` were recently added to the library. Both functions allow you to specify a default user, or to specify the user on the object instances themselves using `_history_user`. However, there's no easy way to get the current user in the same way that we get it for normal historical model creation. This PR updates those bulk create operations such that the user is the same user that would be applied if they were not bulk operations (unless you specify 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
