### PR TITLE
Allow to exclude some fields from `diff_against` check

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -74,6 +74,7 @@ Authors
 - Marty Alchin
 - Matheus Cansian (`mscansian <https://github.com/mscansian>`_)
 - Mauricio de Abreu Antunes
+- Maxim Zemskov (`MaximZemskov <https://github.com/MaximZemskov>`_)
 - Micah Denbraver
 - Michael England
 - Miguel Vargas

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Unreleased
+----------
+- Added ``--excluded_fields`` argument to ``clean_duplicate_history`` command
+
+
 2.11.0 (2020-06-20)
 -------------------
 - Added ``clean_old_history`` management command (gh-675)

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -24,6 +24,12 @@ so you can schedule, for instance, an hourly cronjob such as
 
     $ python manage.py clean_duplicate_history -m 60 --auto
 
+You can also use ``--excluded_fields`` to provide a list of fields to be excluded
+from the duplicate check
+
+.. code-block:: bash
+
+    $ python manage.py clean_duplicate_history --auto --excluded_fields field1 field2
 
 clean_old_history
 -----------------------

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -34,7 +34,7 @@ class Command(populate_history.Command):
         parser.add_argument(
             "--excluded_fields",
             nargs="+",
-            help="List of fields to be excluded " "from the diff_against check",
+            help="List of fields to be excluded from the diff_against check",
         )
 
     def handle(self, *args, **options):

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -32,8 +32,9 @@ class Command(populate_history.Command):
             "-m", "--minutes", type=int, help="Only search the last MINUTES of history"
         )
         parser.add_argument(
-            "--excluded_fields", nargs='+', help="List of fields to be excluded "
-                                                 "from the diff_against check"
+            "--excluded_fields",
+            nargs="+",
+            help="List of fields to be excluded " "from the diff_against check",
         )
 
     def handle(self, *args, **options):

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -31,9 +31,14 @@ class Command(populate_history.Command):
         parser.add_argument(
             "-m", "--minutes", type=int, help="Only search the last MINUTES of history"
         )
+        parser.add_argument(
+            "--excluded_fields", nargs='+', help="List of fields to be excluded "
+                                                 "from the diff_against check"
+        )
 
     def handle(self, *args, **options):
         self.verbosity = options["verbosity"]
+        self.excluded_fields = options.get("excluded_fields")
 
         to_process = set()
         model_strings = options.get("models", []) or args
@@ -109,7 +114,7 @@ class Command(populate_history.Command):
             self.stdout.write(message)
 
     def _check_and_delete(self, entry1, entry2, dry_run=True):
-        delta = entry1.diff_against(entry2)
+        delta = entry1.diff_against(entry2, excluded_fields=self.excluded_fields)
         if not delta.changed_fields:
             if not dry_run:
                 entry1.delete()

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -586,19 +586,22 @@ class HistoricalObjectDescriptor(object):
 
 
 class HistoricalChanges(object):
-    def diff_against(self, old_history):
+    def diff_against(self, old_history, excluded_fields=None):
         if not isinstance(old_history, type(self)):
             raise TypeError(
                 ("unsupported type(s) for diffing: " "'{}' and '{}'").format(
                     type(self), type(old_history)
                 )
             )
-
+        if excluded_fields is None:
+            excluded_fields = []
         changes = []
         changed_fields = []
         old_values = model_to_dict(old_history.instance)
         current_values = model_to_dict(self.instance)
         for field, new_value in current_values.items():
+            if field in excluded_fields:
+                continue
             if field in old_values:
                 old_value = old_values[field]
                 if old_value != new_value:

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -396,8 +396,11 @@ class TestCleanDuplicateHistory(TestCase):
         self.assertEqual(Poll.history.all().count(), 2)
         out = StringIO()
         management.call_command(
-            self.command_name, auto=True, excluded_fields=('pub_date',), stdout=out,
-            stderr=StringIO()
+            self.command_name,
+            auto=True,
+            excluded_fields=("pub_date",),
+            stdout=out,
+            stderr=StringIO(),
         )
         self.assertEqual(
             out.getvalue(),

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -664,10 +664,9 @@ class HistoricalRecordsTest(TestCase):
         p.question = "what's up, man?"
         p.save()
         new_record, old_record = p.history.all()
-        delta = new_record.diff_against(old_record, excluded_fields=('question',))
+        delta = new_record.diff_against(old_record, excluded_fields=("question",))
         self.assertEqual(delta.changed_fields, [])
         self.assertEqual(delta.changes, [])
-
 
 
 class GetPrevRecordAndNextRecordTestCase(TestCase):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -659,6 +659,16 @@ class HistoricalRecordsTest(TestCase):
         with self.assertRaises(TypeError):
             new_record.diff_against("something")
 
+    def test_history_diff_with_excluded_fields(self):
+        p = Poll.objects.create(question="what's up?", pub_date=today)
+        p.question = "what's up, man?"
+        p.save()
+        new_record, old_record = p.history.all()
+        delta = new_record.diff_against(old_record, excluded_fields=('question',))
+        self.assertEqual(delta.changed_fields, [])
+        self.assertEqual(delta.changes, [])
+
+
 
 class GetPrevRecordAndNextRecordTestCase(TestCase):
     def assertRecordsMatch(self, record_a, record_b):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
These changes would allow providing `excluded_fields` argument to `clean_duplicate_history`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/jazzband/django-simple-history/issues/674

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With this changes you can exclude some fields from `diff_against` method and clean not absolute identical instances by call `clean_duplicate_history` command with `--excluded_fields` argument

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See tests in PR.
Also ran command on database with a lot of duplicates with different `version` attribute values.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
