### PR TITLE
feat: add default_date optional parameter for bulk create and update

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -94,6 +94,7 @@ Authors
 - Sergey Ozeranskiy (`ozeranskiy <https://github.com/ozeranskiy>`_)
 - Shane Engelman
 - Steeve Chailloux
+- Stefan Borer (`sbor23 <https://github.com/sbor23>`_)
 - Steven Klass
 - Tommy Beadle (`tbeadle <https://github.com/tbeadle>`_)
 - Trey Hunner (`treyhunner <https://github.com/treyhunner>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changes
 =======
 
+Unreleased
+----------
+- Add default date to ``bulk_create_with_history`` and ``bulk_update_with_history`` (gh-687)
+
 2.11.0 (2020-06-20)
 -------------------
 - Added ``clean_old_history`` management command (gh-675)

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -33,19 +33,20 @@ history:
     1000
 
 If you want to specify a change reason or history user for each record in the bulk create,
-you can add `_change_reason` or `_history_user` on each instance:
+you can add `_change_reason`, `_history_user` or `_history_date` on each instance:
 
 .. code-block:: pycon
 
     >>> for poll in data:
             poll._change_reason = 'reason'
             poll._history_user = my_user
+            poll._history_date = some_date
     >>> objs = bulk_create_with_history(data, Poll, batch_size=500)
     >>> Poll.history.get(id=data[0].id).history_change_reason
     'reason'
 
 You can also specify a default user or default change reason responsible for the change
-(`_history_user` and `_change_reason` take precedence).
+(`_change_reason`, `_history_user` and `_history_date` take precedence).
 
 .. code-block:: pycon
 

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -107,6 +107,7 @@ class HistoryManager(models.Manager):
         update=False,
         default_user=None,
         default_change_reason="",
+        default_date=None,
     ):
         """
         Bulk create the history for the objects specified by objs.
@@ -126,7 +127,9 @@ class HistoryManager(models.Manager):
                 default_user or self.model.get_default_history_user(instance),
             )
             row = self.model(
-                history_date=getattr(instance, "_history_date", timezone.now()),
+                history_date=getattr(
+                    instance, "_history_date", default_date or timezone.now()
+                ),
                 history_user=history_user,
                 history_change_reason=get_change_reason_from_object(instance)
                 or default_change_reason,

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -1,4 +1,5 @@
 from unittest import skipIf
+from datetime import datetime
 
 import django
 from django.contrib.auth import get_user_model
@@ -68,6 +69,14 @@ class BulkCreateWithHistoryTestCase(TestCase):
                     for history in Poll.history.all()
                 ]
             )
+        )
+
+    def test_bulk_create_history_with_default_date(self):
+        date = datetime(2020, 7, 1)
+        bulk_create_with_history(self.data, Poll, default_date=date)
+
+        self.assertTrue(
+            all([history.history_date == date for history in Poll.history.all()])
         )
 
     def test_bulk_create_history_num_queries_is_two(self):
@@ -175,7 +184,11 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
         result = bulk_create_with_history(objects, model)
         self.assertEqual(result, objects)
         hist_manager_mock().bulk_history_create.assert_called_with(
-            objects, batch_size=None, default_user=None, default_change_reason=None
+            objects,
+            batch_size=None,
+            default_user=None,
+            default_change_reason=None,
+            default_date=None,
         )
 
 
@@ -231,6 +244,21 @@ class BulkUpdateWithHistoryTestCase(TestCase):
             all(
                 [
                     history.history_change_reason == "my change reason"
+                    for history in Poll.history.filter(history_type="~")
+                ]
+            )
+        )
+
+    def test_bulk_update_history_with_default_date(self):
+        date = datetime(2020, 7, 1)
+        bulk_update_with_history(
+            self.data, Poll, fields=["question"], default_date=date
+        )
+
+        self.assertTrue(
+            all(
+                [
+                    history.history_date == date
                     for history in Poll.history.filter(history_type="~")
                 ]
             )

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -132,9 +132,7 @@ def bulk_update_with_history(
         )
     history_manager = get_history_manager_for_model(model)
     with transaction.atomic(savepoint=False):
-        model.objects.bulk_update(
-            objs, fields, batch_size=batch_size
-        )
+        model.objects.bulk_update(objs, fields, batch_size=batch_size)
         history_manager.bulk_history_create(
             objs,
             batch_size=batch_size,

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -45,7 +45,12 @@ def get_history_model_for_model(model):
 
 
 def bulk_create_with_history(
-    objs, model, batch_size=None, default_user=None, default_change_reason=None
+    objs,
+    model,
+    batch_size=None,
+    default_user=None,
+    default_change_reason=None,
+    default_date=None,
 ):
     """
     Bulk create the objects specified by objs while also bulk creating
@@ -60,6 +65,8 @@ def bulk_create_with_history(
         record
     :param default_change_reason: Optional change reason to specify as the change_reason
         in each historical record
+    :param default_date: Optional date to specify as the history_date in each historical
+        record
     :return: List of objs with IDs
     """
 
@@ -74,6 +81,7 @@ def bulk_create_with_history(
                 batch_size=batch_size,
                 default_user=default_user,
                 default_change_reason=default_change_reason,
+                default_date=default_date,
             )
     if second_transaction_required:
         obj_list = []
@@ -88,13 +96,20 @@ def bulk_create_with_history(
                 batch_size=batch_size,
                 default_user=default_user,
                 default_change_reason=default_change_reason,
+                default_date=default_date,
             )
         objs_with_id = obj_list
     return objs_with_id
 
 
 def bulk_update_with_history(
-    objs, model, fields, batch_size=None, default_user=None, default_change_reason=None,
+    objs,
+    model,
+    fields,
+    batch_size=None,
+    default_user=None,
+    default_change_reason=None,
+    default_date=None,
 ):
     """
     Bulk update the objects specified by objs while also bulk creating
@@ -107,6 +122,8 @@ def bulk_update_with_history(
         record
     :param default_change_reason: Optional change reason to specify as the change_reason
         in each historical record
+    :param default_date: Optional date to specify as the history_date in each historical
+        record
     """
     if django.VERSION < (2, 2,):
         raise NotImplementedError(
@@ -116,7 +133,7 @@ def bulk_update_with_history(
     history_manager = get_history_manager_for_model(model)
     with transaction.atomic(savepoint=False):
         model.objects.bulk_update(
-            objs, fields, batch_size=batch_size,
+            objs, fields, batch_size=batch_size
         )
         history_manager.bulk_history_create(
             objs,
@@ -124,6 +141,7 @@ def bulk_update_with_history(
             update=True,
             default_user=default_user,
             default_change_reason=default_change_reason,
+            default_date=default_date,
         )
 
 


### PR DESCRIPTION
Add default_date parameter for bulk creating and updating historical entries.

## Description
This change adds a keyword argument `default_date` to the `bulk_history_create()` method on the `HistoryManager`, as well as the utility functions `bulk_create_with_history()` and `bulk_update_with_history()`.
If provided, the created or updated history entries will have the field `history_date` set to this date.

## Related Issue
https://github.com/jazzband/django-simple-history/issues/686

## Motivation and Context
It provides an easy way to set the history_date when dealing with bulk operations.

## How Has This Been Tested?
Unittests have been added.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
