### PR TITLE
Exclude ManyToManyFields when using bulk_create_with_history

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -95,6 +95,7 @@ Authors
 - Shane Engelman
 - Steeve Chailloux
 - Stefan Borer (`sbor23 <https://github.com/sbor23>`_)
+- Steven Buss (`sbuss <https://github.com/sbuss>`_)
 - Steven Klass
 - Tommy Beadle (`tbeadle <https://github.com/tbeadle>`_)
 - Trey Hunner (`treyhunner <https://github.com/treyhunner>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 - Add default date to ``bulk_create_with_history`` and ``bulk_update_with_history`` (gh-687)
+- Exclude ManyToManyFields when using ``bulk_create_with_history`` (gh-699)
 
 2.11.0 (2020-06-20)
 -------------------

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -693,3 +693,13 @@ class ForeignKeyToSelfModel(models.Model):
 class Street(models.Model):
     name = models.CharField(max_length=150)
     log = HistoricalRecords(related_name="history")
+
+
+class BulkCreateManyToManyModelOther(models.Model):
+    name = models.CharField(max_length=15, unique=True)
+
+
+class BulkCreateManyToManyModel(models.Model):
+    name = models.CharField(max_length=15, unique=True)
+    other = models.ManyToManyField(BulkCreateManyToManyModelOther)
+    history = HistoricalRecords()

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -197,11 +197,11 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
 class BulkCreateWithManyToManyField(TestCase):
     def setUp(self):
         self.data = [
-            BulkCreateManyToManyModel(name='Object 1'),
-            BulkCreateManyToManyModel(name='Object 2'),
-            BulkCreateManyToManyModel(name='Object 3'),
-            BulkCreateManyToManyModel(name='Object 4'),
-            BulkCreateManyToManyModel(name='Object 5'),
+            BulkCreateManyToManyModel(name="Object 1"),
+            BulkCreateManyToManyModel(name="Object 2"),
+            BulkCreateManyToManyModel(name="Object 3"),
+            BulkCreateManyToManyModel(name="Object 4"),
+            BulkCreateManyToManyModel(name="Object 5"),
         ]
 
     def test_bulk_create_with_history(self):

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -180,7 +180,8 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
             objects=Mock(
                 bulk_create=Mock(return_value=[Place(name="Place 1")]),
                 filter=Mock(return_value=objects),
-            )
+            ),
+            _meta=Mock(get_fields=Mock(return_value=[])),
         )
         result = bulk_create_with_history(objects, model)
         self.assertEqual(result, objects)

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -10,6 +10,7 @@ from mock import Mock, patch
 
 from simple_history.exceptions import NotHistoricalModelError
 from simple_history.tests.models import (
+    BulkCreateManyToManyModel,
     Document,
     Place,
     Poll,
@@ -190,6 +191,22 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
             default_change_reason=None,
             default_date=None,
         )
+
+
+class BulkCreateWithManyToManyField(TestCase):
+    def setUp(self):
+        self.data = [
+            BulkCreateManyToManyModel(name='Object 1'),
+            BulkCreateManyToManyModel(name='Object 2'),
+            BulkCreateManyToManyModel(name='Object 3'),
+            BulkCreateManyToManyModel(name='Object 4'),
+            BulkCreateManyToManyModel(name='Object 5'),
+        ]
+
+    def test_bulk_create_with_history(self):
+        bulk_create_with_history(self.data, BulkCreateManyToManyModel)
+
+        self.assertEqual(BulkCreateManyToManyModel.objects.count(), 5)
 
 
 @skipIf(django.VERSION < (2, 2,), reason="bulk_update does not exist before 2.2")

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -72,8 +72,11 @@ def bulk_create_with_history(
     """
     # Exclude ManyToManyFields because they end up as invalid kwargs to
     # model.objects.filter(...) below.
-    exclude_fields = [field.name for field in model._meta.get_fields()
-                      if isinstance(field, ManyToManyField)]
+    exclude_fields = [
+        field.name
+        for field in model._meta.get_fields()
+        if isinstance(field, ManyToManyField)
+    ]
     history_manager = get_history_manager_for_model(model)
     second_transaction_required = True
     with transaction.atomic(savepoint=False):
@@ -92,7 +95,10 @@ def bulk_create_with_history(
         with transaction.atomic(savepoint=False):
             for obj in objs_with_id:
                 attributes = dict(
-                    filter(lambda x: x[1] is not None, model_to_dict(obj, exclude=exclude_fields).items())
+                    filter(
+                        lambda x: x[1] is not None,
+                        model_to_dict(obj, exclude=exclude_fields).items(),
+                    )
                 )
                 obj_list += model.objects.filter(**attributes)
             history_manager.bulk_history_create(

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -2,6 +2,7 @@ import warnings
 
 import django
 from django.db import transaction
+from django.db.models import ManyToManyField
 from django.forms.models import model_to_dict
 
 from simple_history.exceptions import NotHistoricalModelError
@@ -69,7 +70,10 @@ def bulk_create_with_history(
         record
     :return: List of objs with IDs
     """
-
+    # Exclude ManyToManyFields because they end up as invalid kwargs to
+    # model.objects.filter(...) below.
+    exclude_fields = [field.name for field in model._meta.get_fields()
+                      if isinstance(field, ManyToManyField)]
     history_manager = get_history_manager_for_model(model)
     second_transaction_required = True
     with transaction.atomic(savepoint=False):
@@ -88,7 +92,7 @@ def bulk_create_with_history(
         with transaction.atomic(savepoint=False):
             for obj in objs_with_id:
                 attributes = dict(
-                    filter(lambda x: x[1] is not None, model_to_dict(obj).items())
+                    filter(lambda x: x[1] is not None, model_to_dict(obj, exclude=exclude_fields).items())
                 )
                 obj_list += model.objects.filter(**attributes)
             history_manager.bulk_history_create(


### PR DESCRIPTION
## Description
Excludes `ManyToManyField`s when using `bulk_create_with_history`.

## Related Issue
#698 

## Motivation and Context
When using `django-simple-history` on a model that has a `ManyToManyField`, one cannot use `bulk_create_with_history`. See #698 for details.

## How Has This Been Tested?
I added a new test and ran it with `python setup.py test` on python3.8 on Ubuntu 20.04.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
