### PR TITLE
Patches for Django warnings

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -103,6 +103,7 @@ Authors
 - `vnagendra <https://github.com/vnagendra>`_
 - `yakimka <https://github.com/yakimka>`_
 - `Paulo Peres <https://github.com/PauloPeres>`_
+- `Alex Todorov <https://github.com/atodorov>`_
 
 Background
 ==========

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -4,7 +4,11 @@ import django
 from django import http
 from django.apps import apps as django_apps
 from django.conf import settings
-from django.conf.urls import url
+
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import unquote

--- a/simple_history/signals.py
+++ b/simple_history/signals.py
@@ -1,23 +1,10 @@
 import django.dispatch
 
 
-pre_create_historical_record = django.dispatch.Signal(
-    providing_args=[
-        "instance",
-        "history_instance",
-        "history_date",
-        "history_user",
-        "history_change_reason",
-        "using",
-    ]
-)
-post_create_historical_record = django.dispatch.Signal(
-    providing_args=[
-        "instance",
-        "history_instance",
-        "history_date",
-        "history_user",
-        "history_change_reason",
-        "using",
-    ]
-)
+# Arguments: "instance",  "history_instance", "history_date",
+#            "history_user", "history_change_reason", "using"
+pre_create_historical_record = django.dispatch.Signal()
+
+# Arguments: "instance",  "history_instance", "history_date",
+#            "history_user", "history_change_reason", "using"
+post_create_historical_record = django.dispatch.Signal()

--- a/simple_history/tests/urls.py
+++ b/simple_history/tests/urls.py
@@ -1,6 +1,9 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 from django.contrib import admin
 
 from simple_history.tests.view import (


### PR DESCRIPTION
## Description
Update how tests are executed and fix some Django warnings that started appearing in 3.1

You can see the warnings here:
https://github.com/kiwitcms/Kiwi/pull/1822/checks?check_run_id=998463212

I tried running the tests with `PYTHONWARNINGS=d` and `DiscoverRunner(verbosity=2)` but that didn't show them in the logs.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
