### PR TITLE
Exclude ManyToManyFields when fetching excluded fields.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -59,6 +59,7 @@ Authors
 - Jonathan Loo (`alpha1d3d <https://github.com/alpha1d3d>`_)
 - Jonathan Sanchez
 - Jonathan Zvesper (`zvesp <https://github.com/zvesp>`_)
+- Jordon Wing  (`jordonwii <https://github.com/jordonwii`_)
 - Josh Fyne
 - Keith Hackbarth
 - Kevin Foster

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 - Add default date to ``bulk_create_with_history`` and ``bulk_update_with_history`` (gh-687)
 - Exclude ManyToManyFields when using ``bulk_create_with_history`` (gh-699)
+- Exclude ManyToManyFields when fetching excluded fields (gh-707)
 
 2.11.0 (2020-06-20)
 -------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -384,6 +384,8 @@ class HistoricalRecords(object):
                 field.attname: getattr(self, field.attname) for field in fields.values()
             }
             if self._history_excluded_fields:
+                # We don't add ManyToManyFields to this list because they may cause
+                # the subsequent `.get()` call to fail. See #706 for context.
                 excluded_attnames = [
                     model._meta.get_field(field).attname
                     for field in self._history_excluded_fields

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -14,7 +14,7 @@ from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from django.db.models import Q
+from django.db.models import ManyToManyField, Q
 from django.db.models.fields.proxy import OrderWrt
 from django.forms.models import model_to_dict
 from django.urls import reverse
@@ -387,6 +387,7 @@ class HistoricalRecords(object):
                 excluded_attnames = [
                     model._meta.get_field(field).attname
                     for field in self._history_excluded_fields
+                    if not isinstance(model._meta.get_field(field), ManyToManyField)
                 ]
                 try:
                     values = (

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -695,11 +695,16 @@ class Street(models.Model):
     log = HistoricalRecords(related_name="history")
 
 
-class BulkCreateManyToManyModelOther(models.Model):
+class ManyToManyModelOther(models.Model):
     name = models.CharField(max_length=15, unique=True)
 
 
 class BulkCreateManyToManyModel(models.Model):
     name = models.CharField(max_length=15, unique=True)
-    other = models.ManyToManyField(BulkCreateManyToManyModelOther)
+    other = models.ManyToManyField(ManyToManyModelOther)
     history = HistoricalRecords()
+
+class ModelWithExcludedManyToMany(models.Model):
+    name = models.CharField(max_length=15, unique=True)
+    other = models.ManyToManyField(ManyToManyModelOther)
+    history = HistoricalRecords(excluded_fields=['other'])

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -704,7 +704,8 @@ class BulkCreateManyToManyModel(models.Model):
     other = models.ManyToManyField(ManyToManyModelOther)
     history = HistoricalRecords()
 
+
 class ModelWithExcludedManyToMany(models.Model):
     name = models.CharField(max_length=15, unique=True)
     other = models.ManyToManyField(ManyToManyModelOther)
-    history = HistoricalRecords(excluded_fields=['other'])
+    history = HistoricalRecords(excluded_fields=["other"])

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1166,7 +1166,14 @@ class TestOrderWrtField(TestCase):
 
         model_state = state.ModelState.from_model(SeriesWork.history.model)
         found = False
-        for name, field in model_state.fields:
+        # `fields` is a dict in Django 3.1
+        fields = None
+        if isinstance(model_state.fields, dict):
+            fields = model_state.fields.items()
+        else:
+            fields = model_state.fields
+
+        for name, field in fields:
             if name == "_order":
                 found = True
                 self.assertEqual(type(field), models.IntegerField)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -998,11 +998,11 @@ class HistoryManagerTest(TestCase):
         self.assertRaises(Poll.DoesNotExist, poll.history.as_of, time)
 
     def test_as_of_excluded_many_to_many_succeeds(self):
-        id1 = ManyToManyModelOther.objects.create(name="test1")
-        id2 = ManyToManyModelOther.objects.create(name="test2")
+        other1 = ManyToManyModelOther.objects.create(name="test1")
+        other2 = ManyToManyModelOther.objects.create(name="test2")
 
         m = ModelWithExcludedManyToMany.objects.create(name="test")
-        m.other.add(id1, id2)
+        m.other.add(other1, other2)
 
         # This will fail if the ManyToMany field is not excluded.
         self.assertEqual(m.history.as_of(datetime.now()), m)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -69,6 +69,8 @@ from ..models import (
     OverrideModelNameUsingBaseModel1,
     MyOverrideModelNameRegisterMethod1,
     Library,
+    ManyToManyModelOther,
+    ModelWithExcludedManyToMany,
     ModelWithFkToModelWithHistoryUsingBaseModelDb,
     ModelWithHistoryInDifferentDb,
     ModelWithHistoryUsingBaseModelDb,
@@ -994,6 +996,16 @@ class HistoryManagerTest(TestCase):
         poll.save()
         poll.delete()
         self.assertRaises(Poll.DoesNotExist, poll.history.as_of, time)
+
+    def test_as_of_excluded_many_to_many_succeeds(self):
+        id1 = ManyToManyModelOther.objects.create(name="test1")
+        id2 = ManyToManyModelOther.objects.create(name="test2")
+
+        m = ModelWithExcludedManyToMany.objects.create(name="test")
+        m.other.add(id1, id2)
+
+        # This will fail if the ManyToMany field is not excluded.
+        self.assertEqual(m.history.as_of(datetime.now()), m)
 
     def test_foreignkey_field(self):
         why_poll = Poll.objects.create(question="why?", pub_date=today)


### PR DESCRIPTION
## Description
Calling `as_of` on a model with an excluded `ManyToManyField` will fail if the related field has more than one object. This is because of the `values(...).get()` call here, which behaves differently for M2M fields than for normal scalar fields: https://github.com/jazzband/django-simple-history/blob/master/simple_history/models.py#L395.

This fixes this by simply excluding M2M fields from the reconstructed object instance. AFAICT this is safe and cheap, because users can query their M2M using the model manager if they want values from it. 

An alternate fix could change the code to avoid `.get()`, but I don't think we actually want to prefetch all of the values of an M2M field here. 

## Related Issue
#706 

## How Has This Been Tested?
Test included.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
