### PR TITLE
Bulk create and update support for alternative managers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,6 +38,7 @@ Authors
 - Filipe Pina (@fopina)
 - Florian Eßer
 - Frank Sachsenheim
+- George Kettleborough (`georgek <https://github.com/georgek>`_)
 - George Vilches
 - Gregory Bataille
 - Grzegorz Bialy

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Unreleased
 - Exclude ManyToManyFields when using ``bulk_create_with_history`` (gh-699)
 - Added ``--excluded_fields`` argument to ``clean_duplicate_history`` command (gh-674)
 - Exclude ManyToManyFields when fetching excluded fields (gh-707)
+- Use default model manager for ``bulk_create_with_history`` and
+  ``bulk_update_with_history`` instead of ``objects`` (gh-703)
+- Add optional ``manager`` argument to ``bulk_update_with_history`` to use instead of
+  the default manager (gh-703)
 
 2.11.0 (2020-06-20)
 -------------------

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -56,9 +56,11 @@ You can also specify a default user or default change reason responsible for the
     True
 
 Bulk Updating a Model with History (New)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Bulk update was introduced with Django 2.2. We can use the utility function
-``bulk_update_with_history`` in order to bulk update objects using Django's ``bulk_update`` function while saving the object history:
+``bulk_update_with_history`` in order to bulk update objects using Django's
+``bulk_update`` function while saving the object history:
 
 
 .. code-block:: pycon
@@ -72,7 +74,19 @@ Bulk update was introduced with Django 2.2. We can use the utility function
     >>> for obj in objs: obj.question = 'Duplicate Questions'
     >>> bulk_update_with_history(objs, Poll, ['question'], batch_size=500)
     >>> Poll.objects.first().question
-    'Duplicate Question'
+    'Duplicate Question``
+
+If your models require the use of an alternative model manager (usually because the
+default manager returns a filtered set), you can specify which manager to use with the
+``manager`` argument:
+
+.. code-block:: pycon
+
+    >>> from simple_history.utils import bulk_update_with_history
+    >>> from simple_history.tests.models import PollWithAlternativeManager
+    >>>
+    >>> data = [PollWithAlternativeManager(id=x, question='Question ' + str(x), pub_date=now()) for x in range(1000)]
+    >>> objs = bulk_create_with_history(data, PollWithAlternativeManager, batch_size=500, manager=PollWithAlternativeManager.all_polls)
 
 QuerySet Updates with History (Updated in Django 2.2)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/simple_history/exceptions.py
+++ b/simple_history/exceptions.py
@@ -19,3 +19,9 @@ class RelatedNameConflictError(Exception):
     """Related name conflicting with history manager"""
 
     pass
+
+
+class AlternativeManagerError(Exception):
+    """Manager does not belong to model"""
+
+    pass

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -63,6 +63,21 @@ class PollWithExcludedFKField(models.Model):
     history = HistoricalRecords(excluded_fields=["place"])
 
 
+class AlternativePollManager(models.Manager):
+    def get_queryset(self):
+        return super(AlternativePollManager, self).get_queryset().exclude(id=1)
+
+
+class PollWithAlternativeManager(models.Model):
+    some_objects = AlternativePollManager()
+    all_objects = models.Manager()
+
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+
+    history = HistoricalRecords()
+
+
 class IPAddressHistoricalModel(models.Model):
     ip_address = models.GenericIPAddressField()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds an optional `manager` parameter to both `bulk_create_with_history` and `bulk_update_with_history`. This is necessary when using models with alternative managers (either because they don't have an `objects` or because `objects` returns a filtered set).

## Related Issue
fixes #703 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Django doesn't require models to have a manager called `objects` and if they do it doesn't necessarily return all objects (so bulk update will not work properly).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added tests for the functionality and possible exception.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
