### PR TITLE
Override "submit_buttons_top" section to prevent KeyError in context

### DIFF
--- a/simple_history/templates/simple_history/object_history_form.html
+++ b/simple_history/templates/simple_history/object_history_form.html
@@ -13,6 +13,10 @@
   </div>
 {% endblock %}
 
+{% block submit_buttons_top %}
+  {% include "simple_history/submit_line.html" %}
+{% endblock %}
+
 {% block submit_buttons_bottom %}
   {% include "simple_history/submit_line.html" %}
 {% endblock %}


### PR DESCRIPTION
This block is rendered conditionally. Will not appear if `save_on_top = False`

Resolves https://github.com/jazzband/django-simple-history/issues/443

## Description
There is a `{% block submit_buttons_top %}` which was being rendered conditionally (if `save_on_top = False` for that model admin). It needed to be overridden the same way as `{% block submit_buttons_bottom %}`

## Related Issue
https://github.com/jazzband/django-simple-history/issues/443

## Motivation and Context
Fixes a `KeyError` on context due to an admin tag getting called where we don't have the right context.

## How Has This Been Tested?
I manually tested this on Django 3.1. It's an incredibly basic change. If there's a version of Django that doesn't have that block, it should just omit it gracefully.

## Screenshots

![Screenshot_2020-09-17 Revert RichText object (1) Django site admin](https://user-images.githubusercontent.com/2071543/93509239-12831080-f8e5-11ea-82ab-7060692463c3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
