### PR TITLE
Add support for Django 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - DJANGO="Django>=2.1,<2.2"
   - DJANGO="Django>=2.2,<2.3"
   - DJANGO="Django>=3.0,<3.1"
+  - DJANGO="Django>=3.1,<3.2"
 
 install:
   - pip install -U coverage codecov
@@ -55,5 +56,11 @@ matrix:
       env: DJANGO="Django>=3.0,<3.1"
     - python: 3.5
       env: DJANGO="Django>=3.0,<3.1"
+    - python: 2.7
+      env: DJANGO="Django>=3.1,<3.2"
+    - python: 3.4
+      env: DJANGO="Django>=3.1,<3.2"
+    - python: 3.5
+      env: DJANGO="Django>=3.1,<3.2"
 
 after_success: codecov

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -37,6 +37,7 @@ Authors
 - Erik van Widenfelt (`erikvw <https://github.com/erikvw>`_)
 - Filipe Pina (@fopina)
 - Florian Eßer
+- François Martin (`martinfrancois <https://github.com/martinfrancois>`_)
 - Frank Sachsenheim
 - George Kettleborough (`georgek <https://github.com/georgek>`_)
 - George Vilches

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Unreleased
   ``bulk_update_with_history`` instead of ``objects`` (gh-703)
 - Add optional ``manager`` argument to ``bulk_update_with_history`` to use instead of
   the default manager (gh-703)
+- Add support for Django 3.1 (gh-713)
 
 2.11.0 (2020-06-20)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ This app supports the following combinations of Django and Python:
 2.1         3.5, 3.6, 3.7
 2.2         3.5, 3.6, 3.7, 3.8
 3.0         3.6, 3.7, 3.8
+3.1         3.6, 3.7, 3.8
 ==========  =======================
 
 Getting Help

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ with open("README.rst") as readme, open("CHANGES.rst") as changes:
             "Framework :: Django :: 2.1",
             "Framework :: Django :: 2.2",
             "Framework :: Django :: 3.0",
+            "Framework :: Django :: 3.1",
             "Programming Language :: Python",
             "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{35,36,37}-django21,
     py{35,36,37,38}-django22,
     py{36,37,38}-django30,
+    py{36,37,38}-django31,
     py{36,37,38}-djangotrunk,
     docs, flake8
 


### PR DESCRIPTION
"Adding support" may be a very generous term here, I didn't need to make any changes to the codebase, it was already compatible and all of the tests are passing :)

## Description
- Run unit tests on Travis CI with Python 3.6, 3.7 and 3.8 and Django 3.1
- Add Django 3.1 as supported in `README` and `setup.py`

## Related Issue
Not sure this warrants discussing in an issue - if this is the case, I don't mind opening one up, just tell me.

## Motivation and Context
It allows all users of `django-simple-history` that want to upgrade to Django 3.1 to upgrade with the confidence that it's supported and helps prevent regression bugs that may be introduced in the future that only affect Django 3.1

## How Has This Been Tested?
I ran the tests locally and on Travis CI.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
