### PR TITLE
Added SECRET_KEY to DEFAULT_SETTINGS

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -36,6 +36,7 @@ class DisableMigrations:
 
 
 DEFAULT_SETTINGS = dict(
+    SECRET_KEY="not a secret",
     ALLOWED_HOSTS=["localhost"],
     AUTH_USER_MODEL="custom_user.CustomUser",
     ROOT_URLCONF="simple_history.tests.urls",


### PR DESCRIPTION
Following this [commit](https://github.com/django/django/commit/948a874425e7d999950a8fa3b6598d9e34a4b861) to Django the `SECRET_KEY` can not be blank. This pull request adds this setting.