### PR TITLE
Add ignore_conflicts to bulk_create_with_history

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -110,6 +110,7 @@ Authors
 - `Paulo Peres <https://github.com/PauloPeres>`_
 - `Alex Todorov <https://github.com/atodorov>`_
 - David Smith (`smithdc1 <https://github.com/smithdc1>`_)
+- Shi Han Ng (`shihanng <https://github.com/shihanng>`_)
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 - Removed support for Django versions prior to 2.2 (gh-652)
 - Migrate from TravisCI to Github Actions (gh-739)
 - Add Python 3.9 support (gh-745)
+- Support ``ignore_conflicts`` in ``bulk_create_with_history`` (gh-733)
 
 2.12.0 (2020-10-14)
 -------------------

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -26,6 +26,13 @@ class Poll(models.Model):
         return reverse("poll-detail", kwargs={"pk": self.pk})
 
 
+class PollWithUniqueQuestion(models.Model):
+    question = models.CharField(max_length=200, unique=True)
+    pub_date = models.DateTimeField("date published")
+
+    history = HistoricalRecords()
+
+
 class PollWithExcludeFields(models.Model):
     question = models.CharField(max_length=200)
     pub_date = models.DateTimeField("date published")

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -49,6 +49,7 @@ def bulk_create_with_history(
     objs,
     model,
     batch_size=None,
+    ignore_conflicts=False,
     default_user=None,
     default_change_reason=None,
     default_date=None,
@@ -82,7 +83,9 @@ def bulk_create_with_history(
 
     second_transaction_required = True
     with transaction.atomic(savepoint=False):
-        objs_with_id = model_manager.bulk_create(objs, batch_size=batch_size)
+        objs_with_id = model_manager.bulk_create(
+            objs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
+        )
         if objs_with_id and objs_with_id[0].pk:
             second_transaction_required = False
             history_manager.bulk_history_create(

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -86,7 +86,7 @@ def bulk_create_with_history(
         objs_with_id = model_manager.bulk_create(
             objs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
         )
-        if objs_with_id and objs_with_id[0].pk:
+        if objs_with_id and objs_with_id[0].pk and not ignore_conflicts:
             second_transaction_required = False
             history_manager.bulk_history_create(
                 objs_with_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If we are to support `ignore_conflicts`, we need to consider that not all item in the list of objects will be bulk created due to conflicts. Then, we also need to make sure that we create history records only for those objects that we created successfully. Unfortunately, we can't rely on the return value of `bulk_create` API because it returns all objects including those it ignores. Therefore, whenever `ignore_conflicts=True` we need to "force" the second transaction to query the created objects.

## Related Issue

Close https://github.com/jazzband/django-simple-history/issues/732

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
