### PR TITLE
fix: do not load historic in memory in clean_old_history command

### DIFF
--- a/simple_history/management/commands/clean_old_history.py
+++ b/simple_history/management/commands/clean_old_history.py
@@ -60,7 +60,7 @@ class Command(populate_history.Command):
             history_model_manager = history_model_manager.filter(
                 history_date__lt=start_date
             )
-            found = len(history_model_manager)
+            found = history_model_manager.count()
             self.log("{0} has {1} old historical entries".format(model, found), 2)
             if not found:
                 continue


### PR DESCRIPTION
uses `query.count()` instead of `len(query)` to count entries to be deleted

## Description

**clean_old_history** command used to count entries to delete with `len()`. This loads in memory all the entries and can lead to crash in case memory limit is reached. Using a sql query to count to entries is faster and safer.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
