### PR TITLE
Add ignore_saving_historical_record_on_delete flag

### DIFF
--- a/docs/querying_history.rst
+++ b/docs/querying_history.rst
@@ -146,6 +146,20 @@ If you want to save a model without a historical record, you can use the followi
     poll.save_without_historical_record()
 
 
+Delete model without saving historical record
+---------------------------------------------
+
+If you have a model that will cause a large number of cascading deletions and 
+you don't wish to save history instances due to performance issues, you can
+set ``ignore_saving_historical_record_on_delete`` to ``True`` on ``HistoricalRecord``
+
+.. code-block:: python
+
+    class Poll(models.Model):
+        question = models.CharField(max_length=200)
+        history = HistoricalRecords(ignore_saving_historical_record_on_delete=True)
+
+
 Filtering data using a relationship to the model
 ------------------------------------------------
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -74,6 +74,7 @@ class HistoricalRecords:
         related_name=None,
         use_base_model_db=False,
         user_db_constraint=True,
+        ignore_saving_historical_record_on_delete=False,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_related_name = user_related_name
@@ -92,6 +93,9 @@ class HistoricalRecords:
         self.user_setter = history_user_setter
         self.related_name = related_name
         self.use_base_model_db = use_base_model_db
+        self.ignore_saving_historical_record_on_delete = (
+            ignore_saving_historical_record_on_delete
+        )
 
         if excluded_fields is None:
             excluded_fields = []
@@ -474,6 +478,8 @@ class HistoricalRecords:
         if self.cascade_delete_history:
             manager = getattr(instance, self.manager_name)
             manager.using(using).all().delete()
+        elif getattr(self, "ignore_saving_historical_record_on_delete", False):
+            return
         else:
             self.create_historical_record(instance, "-", using=using)
 

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -147,6 +147,14 @@ class Choice(models.Model):
     votes = models.IntegerField()
 
 
+class ChoiceWithIgnoredHistoryOnDelete(models.Model):
+    poll = models.ForeignKey(Poll, on_delete=models.CASCADE)
+    choice = models.CharField(max_length=200)
+    votes = models.IntegerField()
+
+    history = HistoricalRecords(ignore_saving_historical_record_on_delete=True)
+
+
 register(Choice)
 
 


### PR DESCRIPTION
## Description
Add ignore_saving_historical_record_on_delete flag on HistoricalRecord model which ignores saving history when a model is deleted. Fixes performance issue when cascading deletions create a large number of history instances.

## Related Issue
Similar to issue #717 

## Motivation and Context
Deleting a model that causes a lot of cascading deletions is slow since it creates a new history instance for each delete, potentially causing thousands of database queries.

## How Has This Been Tested?
Added new unit tests with the flag set to both True/False

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
