### PR TITLE
Removed mock dependency

### DIFF
--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -9,7 +9,7 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 import django
-from mock import ANY, patch
+from unittest.mock import ANY, patch
 
 from simple_history.admin import SimpleHistoryAdmin
 from simple_history.models import HistoricalRecords

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.test import TestCase, TransactionTestCase
 from django.utils import timezone
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from simple_history.exceptions import AlternativeManagerError, NotHistoricalModelError
 from simple_history.tests.models import (

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ python =
 deps =
     coverage
     codecov
-    mock==1.0.1
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2


### PR DESCRIPTION
Mock dependency can be replaced by `unittest.mock`