### PR TITLE
Use asgiref when available instead of thread locals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 - Migrate from TravisCI to Github Actions (gh-739)
 - Add Python 3.9 support (gh-745)
 - Support ``ignore_conflicts`` in ``bulk_create_with_history`` (gh-733)
+- Use ``asgiref`` when available instead of thread locals (gh-747)
 
 2.12.0 (2020-10-14)
 -------------------

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -144,8 +144,8 @@ you use:
 .. code-block:: python
 
     from simple_history.middleware import HistoricalRecords
-    if hasattr(HistoricalRecords.thread, 'request'):
-        del HistoricalRecords.thread.request
+    if hasattr(HistoricalRecords.context, 'request'):
+        del HistoricalRecords.context.request
 
 Using F() expressions
 ---------------------

--- a/docs/historical_model.rst
+++ b/docs/historical_model.rst
@@ -261,8 +261,8 @@ source model. This is possible by combining the ``bases`` functionality with the
     # define your signal handler/callback anywhere outside of models.py
     def add_history_ip_address(sender, **kwargs):
         history_instance = kwargs['history_instance']
-        # thread.request for use only when the simple_history middleware is on and enabled
-        history_instance.ip_address = HistoricalRecords.thread.request.META['REMOTE_ADDR']
+        # context.request for use only when the simple_history middleware is on and enabled
+        history_instance.ip_address = HistoricalRecords.context.request.META['REMOTE_ADDR']
 
 
 .. code-block:: python

--- a/simple_history/middleware.py
+++ b/simple_history/middleware.py
@@ -6,15 +6,15 @@ from .models import HistoricalRecords
 class HistoryRequestMiddleware(MiddlewareMixin):
     """Expose request to HistoricalRecords.
 
-    This middleware sets request as a local thread variable, making it
-    available to the model-level utilities to allow tracking of the
-    authenticated user making a change.
+    This middleware sets request as a local context/thread variable, making it
+    available to the model-level utilities to allow tracking of the authenticated user
+    making a change.
     """
 
     def process_request(self, request):
-        HistoricalRecords.thread.request = request
+        HistoricalRecords.context.request = request
 
     def process_response(self, request, response):
-        if hasattr(HistoricalRecords.thread, "request"):
-            del HistoricalRecords.thread.request
+        if hasattr(HistoricalRecords.context, "request"):
+            del HistoricalRecords.context.request
         return response

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import threading
 import uuid
 import warnings
 
@@ -24,6 +23,11 @@ from .utils import get_change_reason_from_object
 
 from django.utils.translation import gettext_lazy as _
 from django.utils.encoding import smart_str
+
+try:
+    from asgiref.local import Local as LocalContext
+except ImportError:
+    from threading import local as LocalContext
 
 registered_models = {}
 
@@ -51,7 +55,7 @@ def _history_user_setter(historical_instance, user):
 
 
 class HistoricalRecords:
-    thread = threading.local()
+    thread = context = LocalContext()  # retain thread for backwards compatibility
 
     def __init__(
         self,
@@ -529,8 +533,8 @@ class HistoricalRecords:
         except AttributeError:
             request = None
             try:
-                if self.thread.request.user.is_authenticated:
-                    request = self.thread.request
+                if self.context.request.user.is_authenticated:
+                    request = self.context.request
             except AttributeError:
                 pass
 

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -59,7 +59,7 @@ class AdminSiteTest(TestCase):
 
     def tearDown(self):
         try:
-            del HistoricalRecords.thread.request
+            del HistoricalRecords.context.request
         except AttributeError:
             pass
 
@@ -265,7 +265,7 @@ class AdminSiteTest(TestCase):
     def test_middleware_unsets_request(self):
         self.login()
         self.client.get(reverse("admin:tests_book_add"))
-        self.assertFalse(hasattr(HistoricalRecords.thread, "request"))
+        self.assertFalse(hasattr(HistoricalRecords.context, "request"))
 
     @override_settings(**middleware_override_settings)
     def test_rolled_back_user_does_not_lead_to_foreign_key_error(self):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1371,7 +1371,7 @@ class ExtraFieldsStaticIPAddressTestCase(TestCase):
 
 def add_dynamic_history_ip_address(sender, **kwargs):
     history_instance = kwargs["history_instance"]
-    history_instance.ip_address = HistoricalRecords.thread.request.META["REMOTE_ADDR"]
+    history_instance.ip_address = HistoricalRecords.context.request.META["REMOTE_ADDR"]
 
 
 @override_settings(**middleware_override_settings)
@@ -1390,7 +1390,7 @@ class ExtraFieldsDynamicIPAddressTestCase(TestCase):
             dispatch_uid="add_dynamic_history_ip_address",
         )
 
-    def test_signal_is_able_to_retrieve_request_from_thread(self):
+    def test_signal_is_able_to_retrieve_request_from_context(self):
         data = {"question": "Will it blend?", "pub_date": "2018-10-30"}
 
         self.client.post(reverse("pollip-add"), data=data)


### PR DESCRIPTION
## Description
Attempt to use `asgiref.local.Local` when available and fallback to `threading.local` when it isn't available.

## Related Issue
https://github.com/jazzband/django-simple-history/issues/747

## Motivation and Context
Should provide better compatibility with async-capable Django setups

## How Has This Been Tested?
CI

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have run the `make format` command to format my code
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [X] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
