### PR TITLE
Queryset history "as_of" speed improvements

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,6 +23,7 @@ Authors
 - Brian Dixon
 - Carlos San Emeterio (`Carlos-San-Emeterio <https://github.com/Carlos-San-Emeterio>`_)
 - Christopher Broderick (`uhurusurfa <https://github.com/uhurusurfa>`_)
+- Christopher Johns (`tyrantwave <https://github.com/tyrantwave>`_)
 - Corey Bertram
 - Craig Maloney (`craigmaloney <https://github.com/craigmaloney>`_)
 - Damien Nozay

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 - Support ``ignore_conflicts`` in ``bulk_create_with_history`` (gh-733)
 - Use ``asgiref`` when available instead of thread locals (gh-747)
 - Sort imports with isort (gh-751)
+- Queryset ``history.as_of`` speed improvements by calculating in the DB (gh-758)
 
 2.12.0 (2020-10-14)
 -------------------

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -92,7 +92,7 @@ class HistoryManager(models.Manager):
         queryset = self.get_queryset().filter(history_date__lte=date)
         latest_pk_attr_historic_ids = (
             queryset.filter(**{pk_attr: OuterRef(pk_attr)})
-            .order_by("-pk")
+            .order_by("-history_date", "-pk")
             .values("pk")[:1]
         )
         latest_historics = queryset.filter(

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -1,4 +1,4 @@
-from django.db import models, connection
+from django.db import connection, models
 from django.db.models import OuterRef, Subquery
 from django.utils import timezone
 


### PR DESCRIPTION
Now calculates the differences purely in-database, offering a significant speed increase over python.

## Description
Queryset history _as_of_set now uses in-db methods to calculate history at a given time.

## Related Issue
https://github.com/jazzband/django-simple-history/issues/758

## Motivation and Context
Performance increase on large datasets.
On a test set of data with ~46,000 current items and ~80,000 historical entries, time needed to get the full set of changes and filter them reduced from ~15 minutes to ~2 seconds.

## How Has This Been Tested?
Tested against test suite, all passed.

Tested with large datasets, confirmed the same data is returned with & without the change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. - No change in functionality, so the same documentation applies.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. -- No change in functionality, so the same tests apply.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [X] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
