### PR TITLE
Diff improvements (performance + `included_fields`)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 - Fixed bug where serializer of djangorestframework crashed if used with ``OrderingFilter`` (gh-821)
 - Fixed `make format` so it works by using tox (gh-859)
 - Fixed bug where latest() is not idempotent for identical ``history_date`` records (gh-861)
+- Support ``included_fields`` for ``history.diff_against`` (gh-776)
+- Improve performance of ``history.diff_against`` by reducing number of queries to 0 in most cases (gh-776)
 
 3.0.0 (2021-04-16)
 ------------------

--- a/docs/history_diffing.rst
+++ b/docs/history_diffing.rst
@@ -20,3 +20,5 @@ This may be useful when you want to construct timelines and need to get only the
     delta = new_record.diff_against(old_record)
     for change in delta.changes:
         print("{} changed from {} to {}".format(change.field, change.old, change.new))
+
+``diff_against`` also accepts 2 arguments ``excluded_fields`` and ``included_fields`` to either explicitly include or exclude fields from being diffed.

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -585,7 +585,7 @@ class HistoricalObjectDescriptor:
 
 
 class HistoricalChanges:
-    def diff_against(self, old_history, excluded_fields=None):
+    def diff_against(self, old_history, excluded_fields=None, included_fields=None):
         if not isinstance(old_history, type(self)):
             raise TypeError(
                 ("unsupported type(s) for diffing: " "'{}' and '{}'").format(
@@ -595,13 +595,10 @@ class HistoricalChanges:
         if excluded_fields is None:
             excluded_fields = set()
 
-        excluded_fields = set(excluded_fields).union(self._history_excluded_fields)
+        if included_fields is None:
+            included_fields = {f.name for f in old_history.instance_type._meta.fields}
 
-        fields = {
-            f.name
-            for f in old_history.instance_type._meta.fields
-            if f.name not in excluded_fields
-        }
+        fields = set(included_fields).difference(excluded_fields)
 
         changes = []
         changed_fields = []

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -11,6 +11,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import ManyToManyField
 from django.db.models.fields.proxy import OrderWrt
+from django.forms.models import model_to_dict
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import smart_str
@@ -603,9 +604,15 @@ class HistoricalChanges:
         changes = []
         changed_fields = []
 
+        old_values = model_to_dict(old_history, fields=fields)
+        current_values = model_to_dict(self, fields=fields)
+
         for field in fields:
-            old_value = getattr(old_history, field)
-            current_value = getattr(self, field)
+            try:
+                old_value = old_values[field]
+                current_value = current_values[field]
+            except KeyError:
+                continue
 
             if old_value != current_value:
                 changes.append(ModelChange(field, old_value, current_value))

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -608,11 +608,8 @@ class HistoricalChanges:
         current_values = model_to_dict(self, fields=fields)
 
         for field in fields:
-            try:
-                old_value = old_values[field]
-                current_value = current_values[field]
-            except KeyError:
-                continue
+            old_value = old_values[field]
+            current_value = current_values[field]
 
             if old_value != current_value:
                 changes.append(ModelChange(field, old_value, current_value))

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -623,7 +623,8 @@ class HistoricalRecordsTest(TestCase):
         p.question = "what's up, man?"
         p.save()
         new_record, old_record = p.history.all()
-        delta = new_record.diff_against(old_record)
+        with self.assertNumQueries(0):
+            delta = new_record.diff_against(old_record)
         expected_change = ModelChange("question", "what's up?", "what's up, man")
         self.assertEqual(delta.changed_fields, ["question"])
         self.assertEqual(delta.old_record, old_record)
@@ -635,7 +636,8 @@ class HistoricalRecordsTest(TestCase):
         p.question = "what's up, man?"
         p.save()
         new_record, old_record = p.history.all()
-        delta = new_record.diff_against(old_record)
+        with self.assertNumQueries(0):
+            delta = new_record.diff_against(old_record)
         self.assertNotIn("pub_date", delta.changed_fields)
 
     def test_history_diff_includes_changed_fields_of_base_model(self):
@@ -644,7 +646,9 @@ class HistoricalRecordsTest(TestCase):
         r.name = "DonnutsKing"
         r.save()
         new_record, old_record = r.history.all()
-        delta = new_record.diff_against(old_record)
+        # Two queries due to base lookup
+        with self.assertNumQueries(2):
+            delta = new_record.diff_against(old_record)
         expected_change = ModelChange("name", "McDonna", "DonnutsKing")
         self.assertEqual(delta.changed_fields, ["name"])
         self.assertEqual(delta.old_record, old_record)
@@ -664,7 +668,8 @@ class HistoricalRecordsTest(TestCase):
         p.question = "what's up, man?"
         p.save()
         new_record, old_record = p.history.all()
-        delta = new_record.diff_against(old_record, excluded_fields=("question",))
+        with self.assertNumQueries(0):
+            delta = new_record.diff_against(old_record, excluded_fields=("question",))
         self.assertEqual(delta.changed_fields, [])
         self.assertEqual(delta.changes, [])
 
@@ -673,11 +678,13 @@ class HistoricalRecordsTest(TestCase):
         p.question = "what's up, man?"
         p.save()
         new_record, old_record = p.history.all()
-        delta = new_record.diff_against(old_record, included_fields=[])
+        with self.assertNumQueries(0):
+            delta = new_record.diff_against(old_record, included_fields=[])
         self.assertEqual(delta.changed_fields, [])
         self.assertEqual(delta.changes, [])
 
-        delta = new_record.diff_against(old_record, included_fields=["question"])
+        with self.assertNumQueries(0):
+            delta = new_record.diff_against(old_record, included_fields=["question"])
         self.assertEqual(delta.changed_fields, ["question"])
         self.assertEqual(len(delta.changes), 1)
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -668,6 +668,19 @@ class HistoricalRecordsTest(TestCase):
         self.assertEqual(delta.changed_fields, [])
         self.assertEqual(delta.changes, [])
 
+    def test_history_diff_with_included_fields(self):
+        p = Poll.objects.create(question="what's up?", pub_date=today)
+        p.question = "what's up, man?"
+        p.save()
+        new_record, old_record = p.history.all()
+        delta = new_record.diff_against(old_record, included_fields=[])
+        self.assertEqual(delta.changed_fields, [])
+        self.assertEqual(delta.changes, [])
+
+        delta = new_record.diff_against(old_record, included_fields=["question"])
+        self.assertEqual(delta.changed_fields, ["question"])
+        self.assertEqual(len(delta.changes), 1)
+
 
 class GetPrevRecordAndNextRecordTestCase(TestCase):
     def assertRecordsMatch(self, record_a, record_b):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -646,8 +646,7 @@ class HistoricalRecordsTest(TestCase):
         r.name = "DonnutsKing"
         r.save()
         new_record, old_record = r.history.all()
-        # Two queries due to base lookup
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(0):
             delta = new_record.diff_against(old_record)
         expected_change = ModelChange("name", "McDonna", "DonnutsKing")
         self.assertEqual(delta.changed_fields, ["name"])

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -687,6 +687,18 @@ class HistoricalRecordsTest(TestCase):
         self.assertEqual(delta.changed_fields, ["question"])
         self.assertEqual(len(delta.changes), 1)
 
+    def test_history_with_unknown_field(self):
+        p = Poll.objects.create(question="what's up?", pub_date=today)
+        p.question = "what's up, man?"
+        p.save()
+        new_record, old_record = p.history.all()
+        with self.assertRaises(KeyError):
+            with self.assertNumQueries(0):
+                new_record.diff_against(old_record, included_fields=["unknown_field"])
+
+        with self.assertNumQueries(0):
+            new_record.diff_against(old_record, excluded_fields=["unknown_field"])
+
 
 class GetPrevRecordAndNextRecordTestCase(TestCase):
     def assertRecordsMatch(self, record_a, record_b):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Reduce the number of queries needed when calling `diff_against` (down to 0). 

Also implement `included_fields`, so only certain fields will be compared. In this new implementation of diffing, old fields won't be compared at all, and can be deferred from querying if needed.

## Related Issue

N/A for performance improvement.

`included_fields` was mentioned in https://github.com/jazzband/django-simple-history/pull/576#issuecomment-584761832, and as I was here, I added. Can extract into a separate PR if needed.

## Motivation and Context

`model_to_dict` will do queries for M2M fields against real tables. As the history tables don't use actual relationships, it's safe to use those for the lookups without additional queries. Removing this removes accidental queries on models with M2M fields, and stops loading them into memory unnecessarily.

Additionally, diffing involved getting real instances of the model using `.instance`, which was unnecessary. The diffing can be using the history instances directly, saving a lot of computation. The fields list is pulled off the real model which means `history_*`fields are still excluded correctly. `.instance` will sometimes do queries, hence removing the need for this can additionally improve performance.

There are also additional tests to check that diffing is pure and doesn't touch the DB, to help prevent regressions. 

## How Has This Been Tested?

- [x] Tests have been added to cover changes

- [x] Has been run against live project unittests successfully

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
