### PR TITLE
Add next and previous record diffs

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -406,6 +406,18 @@ class HistoricalRecords:
                 .first()
             )
 
+        def get_next_record_diff(self):
+            """
+            Get the difference between this and the next record. `None` of no next record.
+            """
+            
+            next_record = self.get_prev_record()
+            
+            if next_record is not None:
+                return self.diff_against(previous_record)
+            
+            return None
+
         def get_prev_record(self):
             """
             Get the previous history record for the instance. `None` if first.
@@ -416,6 +428,18 @@ class HistoricalRecords:
                 .order_by("history_date")
                 .last()
             )
+
+        def get_prev_record_diff(self):
+            """
+            Get the difference between this and the previous record. `None` if no previous record.
+            """
+            
+            previous_record = self.get_prev_record()
+            
+            if previous_record is not None:
+                return self.diff_against(previous_record)
+            
+            return None
 
         def get_default_history_user(instance):
             """
@@ -438,7 +462,9 @@ class HistoricalRecords:
             "instance": property(get_instance),
             "instance_type": model,
             "next_record": property(get_next_record),
+            "next_record_diff": property(get_next_record_diff),
             "prev_record": property(get_prev_record),
+            "prev_record_diff": property(get_prev_record_diff),
             "revert_url": revert_url,
             "__str__": lambda self: "{} as of {}".format(
                 self.history_object, self.history_date


### PR DESCRIPTION
Closes #797

Added next and previous record diffs for consistency

## Description
These helper properties would make it easier to get revision diffs in Django templlates.

## Related Issue
https://github.com/jazzband/django-simple-history/issues/797

## Motivation and Context
Making it easier to show revision diffs directly in templates.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `make format` command to format my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
