### PR TITLE
Updated test matrix -- Django Dev dropped support for Python3.6 and 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,12 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9']
         django-version: ['2.2', '3.0', '3.1', 'dev']
 
+        exclude:
+        - python-version: '3.6'
+          django-version: 'dev'
+        - python-version: '3.7'
+          django-version: 'dev'
+
     services:
 
       postgres:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31,dev}-{sqlite3,postgres,mysql,mariadb},
+    py{36,37,38,39}-dj{22,30,31}-{sqlite3,postgres,mysql,mariadb},
+    py{38,39}-dj{dev}-{sqlite3,postgres,mysql,mariadb},
     docs,
     lint
 


### PR DESCRIPTION
Updated test matrix -- Django Dev dropped support for Python3.6 and 3.7

## Description
Django's master branch has now dropped support for Python 3.6 and 3.7. Djang 3.2 will be the last version to support these Python versions. 

## Related Issue
#799 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I've tested this on my own fork and have seen the github action tests now passing with this patch.
I've not updated the changelog as I've not actually changed anything that would be included in the release. I think this will come when Django 4.0 support is released (some time yet!)

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ x ] All new and existing tests passed.
