### PR TITLE
Base manager can now be used for clean_duplicate_history

### DIFF
--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -36,10 +36,19 @@ class Command(populate_history.Command):
             nargs="+",
             help="List of fields to be excluded from the diff_against check",
         )
+        parser.add_argument(
+            "--base-manager",
+            action="store_true",
+            default=False,
+            help="Use Django's base manager to dump all models stored in the database,"
+            " including those that would otherwise be filtered or modified by a"
+            " custom manager.",
+        )
 
     def handle(self, *args, **options):
         self.verbosity = options["verbosity"]
         self.excluded_fields = options.get("excluded_fields")
+        self.base_manager = options.get("base_manager")
 
         to_process = set()
         model_strings = options.get("models", []) or args
@@ -72,7 +81,10 @@ class Command(populate_history.Command):
                 continue
 
             # Break apart the query so we can add additional filtering
-            model_query = model.objects.all()
+            if self.base_manager:
+                model_query = model._base_manager.all()
+            else:
+                model_query = model._default_manager.all()
 
             # If we're provided a stop date take the initial hit of getting the
             # filtered records to iterate over

--- a/simple_history/registry_tests/tests.py
+++ b/simple_history/registry_tests/tests.py
@@ -198,7 +198,7 @@ class TestTrackingInheritance(TestCase):
 
 
 class TestCustomAttrForeignKey(TestCase):
-    """ https://github.com/jazzband/django-simple-history/issues/431 """
+    """https://github.com/jazzband/django-simple-history/issues/431"""
 
     def test_custom_attr(self):
         field = ModelWithCustomAttrForeignKey.history.model._meta.get_field("poll")
@@ -219,7 +219,7 @@ class TestMigrate(TestCase):
 
 
 class TestModelWithHistoryInDifferentApp(TestCase):
-    """ https://github.com/jazzband/django-simple-history/issues/485 """
+    """https://github.com/jazzband/django-simple-history/issues/485"""
 
     def test__different_app(self):
         appLabel = ModelWithHistoryInDifferentApp.history.model._meta.app_label

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -82,6 +82,22 @@ class PollWithAlternativeManager(models.Model):
     history = HistoricalRecords()
 
 
+class CustomPollManager(models.Manager):
+    def get_queryset(self):
+        return super(CustomPollManager, self).get_queryset().exclude(hidden=True)
+
+
+class PollWithCustomManager(models.Model):
+    some_objects = CustomPollManager()
+    all_objects = models.Manager()
+
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    hidden = models.BooleanField(default=False)
+
+    history = HistoricalRecords()
+
+
 class IPAddressHistoricalModel(models.Model):
     ip_address = models.GenericIPAddressField()
 

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -17,8 +17,8 @@ from ..models import (
     CustomManagerNameModel,
     Place,
     Poll,
+    PollWithCustomManager,
     PollWithExcludeFields,
-    PollWithAlternativeManager,
     Restaurant,
 )
 
@@ -285,36 +285,33 @@ class TestCleanDuplicateHistory(TestCase):
         self.assertEqual(Poll.history.all().count(), 2)
 
     def _prepare_cleanup_manager(self):
-        one = PollWithAlternativeManager._default_manager.create(
+        one = PollWithCustomManager._default_manager.create(
             question="This is hidden in default manager",
-            pub_date=datetime.now()
+            pub_date=datetime.now(),
+            hidden=True,
         )
         one.save()
 
-        two = PollWithAlternativeManager._default_manager.create(
-            question="This is visible in default manager",
-            pub_date=datetime.now()
+        two = PollWithCustomManager._default_manager.create(
+            question="This is visible in default manager", pub_date=datetime.now()
         )
         two.save()
 
-        self.assertEqual(PollWithAlternativeManager.history.count(), 4)
+        self.assertEqual(PollWithCustomManager.history.count(), 4)
 
     def test_auto_cleanup_defaultmanager(self):
         self._prepare_cleanup_manager()
 
         out = StringIO()
         management.call_command(
-            self.command_name,
-            auto=True,
-            stdout=out,
-            stderr=StringIO()
+            self.command_name, auto=True, stdout=out, stderr=StringIO()
         )
         self.assertEqual(
             out.getvalue(),
             "Removed 1 historical records for "
-            "<class 'simple_history.tests.models.PollWithAlternativeManager'>\n",
+            "<class 'simple_history.tests.models.PollWithCustomManager'>\n",
         )
-        self.assertEqual(PollWithAlternativeManager.history.count(), 3)
+        self.assertEqual(PollWithCustomManager.history.count(), 3)
 
     def test_auto_cleanup_basemanage(self):
         self._prepare_cleanup_manager()
@@ -325,16 +322,16 @@ class TestCleanDuplicateHistory(TestCase):
             auto=True,
             base_manager=True,
             stdout=out,
-            stderr=StringIO()
+            stderr=StringIO(),
         )
         self.assertEqual(
             out.getvalue(),
             "Removed 1 historical records for "
-            "<class 'simple_history.tests.models.PollWithAlternativeManager'>\n"
+            "<class 'simple_history.tests.models.PollWithCustomManager'>\n"
             "Removed 1 historical records for "
-            "<class 'simple_history.tests.models.PollWithAlternativeManager'>\n",
+            "<class 'simple_history.tests.models.PollWithCustomManager'>\n",
         )
-        self.assertEqual(PollWithAlternativeManager.history.count(), 2)
+        self.assertEqual(PollWithCustomManager.history.count(), 2)
 
     def test_auto_cleanup_verbose(self):
         p = Poll.objects.create(

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -18,6 +18,7 @@ from ..models import (
     Place,
     Poll,
     PollWithExcludeFields,
+    PollWithAlternativeManager,
     Restaurant,
 )
 
@@ -282,6 +283,58 @@ class TestCleanDuplicateHistory(TestCase):
             "<class 'simple_history.tests.models.Poll'>\n",
         )
         self.assertEqual(Poll.history.all().count(), 2)
+
+    def _prepare_cleanup_manager(self):
+        one = PollWithAlternativeManager._default_manager.create(
+            question="This is hidden in default manager",
+            pub_date=datetime.now()
+        )
+        one.save()
+
+        two = PollWithAlternativeManager._default_manager.create(
+            question="This is visible in default manager",
+            pub_date=datetime.now()
+        )
+        two.save()
+
+        self.assertEqual(PollWithAlternativeManager.history.count(), 4)
+
+    def test_auto_cleanup_defaultmanager(self):
+        self._prepare_cleanup_manager()
+
+        out = StringIO()
+        management.call_command(
+            self.command_name,
+            auto=True,
+            stdout=out,
+            stderr=StringIO()
+        )
+        self.assertEqual(
+            out.getvalue(),
+            "Removed 1 historical records for "
+            "<class 'simple_history.tests.models.PollWithAlternativeManager'>\n",
+        )
+        self.assertEqual(PollWithAlternativeManager.history.count(), 3)
+
+    def test_auto_cleanup_basemanage(self):
+        self._prepare_cleanup_manager()
+
+        out = StringIO()
+        management.call_command(
+            self.command_name,
+            auto=True,
+            base_manager=True,
+            stdout=out,
+            stderr=StringIO()
+        )
+        self.assertEqual(
+            out.getvalue(),
+            "Removed 1 historical records for "
+            "<class 'simple_history.tests.models.PollWithAlternativeManager'>\n"
+            "Removed 1 historical records for "
+            "<class 'simple_history.tests.models.PollWithAlternativeManager'>\n",
+        )
+        self.assertEqual(PollWithAlternativeManager.history.count(), 2)
 
     def test_auto_cleanup_verbose(self):
         p = Poll.objects.create(

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1189,7 +1189,7 @@ class TestOrderWrtField(TestCase):
 
 
 class TestLatest(TestCase):
-    """"Test behavior of `latest()` without any field parameters"""
+    """ "Test behavior of `latest()` without any field parameters"""
 
     def setUp(self):
         poll = Poll.objects.create(question="Does `latest()` work?", pub_date=yesterday)


### PR DESCRIPTION
## Description
clean_duplicate_history uses `objects` as manager. This has now been changed to `_default_manager` and an option added to use `_base_mananger`.

## Related Issue
none

## Motivation and Context
We use a manager to filter records by default, however we want to remove all records from duplicates.

## How Has This Been Tested?
The command was first run without parameters and then with the new `--base-manager` parameter.

## Screenshots (if appropriate):
none

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
