### PR TITLE
Fix bug where descriptor class missed instance=None case

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,7 @@ Authors
 - Hamish Downer
 - Hanyin Zhang
 - Hernan Esteves (`sevetseh28 <https://github.com/sevetseh28>`_)
+- Hielke Walinga (`hwalinga <https://github.com/hwalinga>`_)
 - Jack Cushman (`jcushman <https://github.com/jcushman>`_)
 - James Muranga (`jamesmura <https://github.com/jamesmura>`_)
 - James Pulec

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 Unreleased
 ----------
 
+ - Fixed bug where serializer of djangorestframework crashed if used with ``OrderingFilter`` (gh-821)
+
 3.0.0 (2021-04-16)
 ------------------
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -579,6 +579,8 @@ class HistoricalObjectDescriptor:
         self.fields_included = fields_included
 
     def __get__(self, instance, owner):
+        if instance is None:
+            return self
         values = {f.attname: getattr(instance, f.attname) for f in self.fields_included}
         return self.model(**values)
 


### PR DESCRIPTION
## Description
#### Return self if called on the class instead of instance to not error when used with djangorestframework

Some metaprogramming magic in djangorestframework performs a check on getting all the `property` object attributes on a django model. As this loops over all attributes it will also arrive at the `history_object` which is implemented with a descriptor. However, this implementation does not account for being accessed on the class instead of the model. (So `instance` is None.) 

This PR just returns self when that happens. This does not interfere with this metaprogramming done, and makes django-simple-history usable again in combination with djangorestframework. 

Returning self in `__get__` when instance is None is the canonical way of doing this, as explained here:

https://stackoverflow.com/questions/29436716/why-do-you-need-if-instance-is-none-in-get-of-a-descriptor-class

## Related Issue
Fixes #821 

## Motivation and Context
Fixed #821 

## How Has This Been Tested?
I have created the fix and installed it in a project that suffered from this bug and it worked. I don't think we should be pulling in djangorestframework for this?

## Types of changes
Descriptor now accounts for being accessed on the class not the instance. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code
- [ ] My change requires a change to the documentation. *(They don't)*
- [ ] I have updated the documentation accordingly. *(No docs need updating)*
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (Manually confirmed fix)
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst` 
- [x] All new and existing tests passed.