### PR TITLE
Fix documentation display issue

### DIFF
--- a/docs/historical_model.rst
+++ b/docs/historical_model.rst
@@ -26,7 +26,7 @@ The example below uses a ``UUIDField`` instead of an ``AutoField``:
 
 
 Since using a ``UUIDField`` for the ``history_id`` is a common use case, there is a
-``SIMPLE_HISTORY_HISTORY_ID_USE_UUID`` setting that will set all ``history_id``s to UUIDs.
+``SIMPLE_HISTORY_HISTORY_ID_USE_UUID`` setting that will set all instances of ``history_id`` to UUIDs.
 Set this with the following line in your ``settings.py`` file:
 
 


### PR DESCRIPTION
The plural seems to confuse the double backticks.

Before:
![image](https://user-images.githubusercontent.com/154364/119977835-caa6a400-bfb0-11eb-810b-96df6c90cd6f.png)