### PR TITLE
Add queryset filtering on HistoryManager with `as_of` support.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -56,6 +56,7 @@ Authors
 - Jesse Shapiro
 - Jihoon Baek (`jihoon796 <https://github.com/jihoon796>`_)
 - Jim Gomez
+- Jim King (`jeking3 <https://github.com/jeking3>`_)
 - Joao Junior (`joaojunior <https://github.com/joaojunior>`_)
 - Joao Pedro Francese
 - `jofusa <https://github.com/jofusa>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changes
 Unreleased
 ----------
 
- - Fixed bug where serializer of djangorestframework crashed if used with ``OrderingFilter`` (gh-821)
+- Fixed bug where serializer of djangorestframework crashed if used with ``OrderingFilter`` (gh-821)
+- Allow for queryset based ``as_of`` filtering with optional conversion to genuine records (gh-397)
+- ``as_of`` now allows for additional filter parameters (gh-397)
 
 3.0.0 (2021-04-16)
 ------------------

--- a/docs/querying_history.rst
+++ b/docs/querying_history.rst
@@ -109,6 +109,25 @@ the provided date and time.
     >>> poll.history.as_of(datetime(2010, 10, 25, 18, 5, 0))
     <Poll: Poll object as of 2010-10-25 18:04:13.814128>
 
+The ``as_of`` method returns a generator - not a queryset.  If you want to build a
+complex point-in-time query, you can express ``as_of`` through a filter() like so:
+
+.. code-block:: pycon
+
+    >>> from datetime import datetime
+    >>> poll.history.filter(as_of=datetime(2010, 10, 25, 18, 4, 0))
+    <HistoricalQuerySet [<HistoricalPoll: Poll object as of 2010-10-25 18:03:29.855689>]>
+
+If you want the resulting queryset to return genuine instances instead of
+historical records, you can tell the queryset to do that:
+
+.. code-block:: pycon
+
+    >>> from datetime import datetime
+    >>> poll.history.filter(as_of=datetime(2010, 10, 25, 18, 4, 0)).as_original()
+    <HistoricalQuerySet [<Poll: Poll object as of 2010-10-25 18:03:29.855689>]>
+
+
 most_recent
 -----------
 

--- a/simple_history/exceptions.py
+++ b/simple_history/exceptions.py
@@ -25,3 +25,9 @@ class AlternativeManagerError(Exception):
     """Manager does not belong to model"""
 
     pass
+
+
+class CannotSwitchQuerySetResultTypeError(Exception):
+    """Cannot call as_original once a queryset has fetched."""
+
+    pass

--- a/simple_history/registry_tests/tests.py
+++ b/simple_history/registry_tests/tests.py
@@ -198,7 +198,7 @@ class TestTrackingInheritance(TestCase):
 
 
 class TestCustomAttrForeignKey(TestCase):
-    """ https://github.com/jazzband/django-simple-history/issues/431 """
+    """https://github.com/jazzband/django-simple-history/issues/431"""
 
     def test_custom_attr(self):
         field = ModelWithCustomAttrForeignKey.history.model._meta.get_field("poll")
@@ -219,7 +219,7 @@ class TestMigrate(TestCase):
 
 
 class TestModelWithHistoryInDifferentApp(TestCase):
-    """ https://github.com/jazzband/django-simple-history/issues/485 """
+    """https://github.com/jazzband/django-simple-history/issues/485"""
 
     def test__different_app(self):
         appLabel = ModelWithHistoryInDifferentApp.history.model._meta.app_label

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -229,6 +229,7 @@ class Document(models.Model):
     changed_by = models.ForeignKey(
         User, on_delete=models.CASCADE, null=True, blank=True
     )
+
     history = HistoricalRecords()
 
     @property
@@ -245,6 +246,12 @@ class Paper(Document):
     @Document._history_user.setter
     def _history_user(self, value):
         self.changed_by = value
+
+
+class RankedDocument(Document):
+    rank = models.IntegerField(default=50)
+
+    history = HistoricalRecords()
 
 
 class Profile(User):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -1189,7 +1189,7 @@ class TestOrderWrtField(TestCase):
 
 
 class TestLatest(TestCase):
-    """"Test behavior of `latest()` without any field parameters"""
+    """ "Test behavior of `latest()` without any field parameters"""
 
     def setUp(self):
         poll = Poll.objects.create(question="Does `latest()` work?", pub_date=yesterday)
@@ -1219,7 +1219,8 @@ class TestLatest(TestCase):
         self.write_history(
             [{"pk": 1, "history_date": yesterday}, {"pk": 2, "history_date": yesterday}]
         )
-        assert HistoricalPoll.objects.latest().pk == 1
+        # not idempotent, see open PRs
+        assert HistoricalPoll.objects.latest().pk in (1, 2)
 
 
 class TestMissingOneToOne(TestCase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The discussion in #397 is about using filtering and querysets with point-in-time queries.  The current `as_of` implementation returns a generator so it can only be used to make a single query and obtain the result.  It does convert those results to the genuine model.  The ideal solution would allow someone to express the following:

```python
    queryset = MyModel.history.filter(as_of=<datetime>, ...)
```

That's what this pull request provides.  One of the challenges with `as_of` filtering is handling deletions; the logic is not trivial and requires a subquery.  When querying this way you get a queryset that returns Historical models, unless you tell it you want genuine instances:

```python
    queryset = MyModel.history.filter(as_of=<datetime>, ...).as_original()
```

Calling `as_original` on the queryset will cause it to return genuine instances instead of historical records.  You can still query directly on `history_date` if you want to be able to retrieve deletion records.  You cannot query on as_of with any qualifiers like `__lte`.

I had originally made the as_of query a method on the HistoryManager called `as_of_filter`.  One benefit to this approach is that if the original model had a field named `as_of` there would not be a conflict.  However it seems more natural to allow an as_of filter expression, so that's what I'm submitting as a solution.

Also note there is a small test change to deal with #862 before it gets merged.

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#118
#229
#354
This closes #397
#715
#758
This closes #803

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

A long-standing issue that kept me from using the library effectively.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests were added, all tests pass.  Additionally, I am integrating the changes into a prototype that was working based on work in #354.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have run the `make format` command to format my code
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [X] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
