### PR TITLE
Added support for Django 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.1', '3.2', 'main']
+        django-version: ['2.2', '3.1', '3.2', '4.0rc1', 'main']
 
         exclude:
           - python-version: '3.6'
@@ -23,6 +23,10 @@ jobs:
             django-version: '2.2'
           - python-version: '3.10'
             django-version: '3.1'
+          - python-version: '3.6'
+            django-version: '4.0b1'
+          - python-version: '3.7'
+            django-version: '4.0b1'
 
     services:
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,6 +33,7 @@ Authors
 - Daniil Skrobov (`yetanotherape <https://github.com/yetanotherape>`_)
 - David Grochowski (`ThePumpingLemma <https://github.com/ThePumpingLemma>`_)
 - David Hite
+- David Smith
 - Dmytro Shyshov (`xahgmah <https://github.com/xahgmah>`_)
 - Edouard Richard (`vied12 <https://github.com/vied12>` _)
 - Eduardo Cuducos

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Full list of changes:
 - Added ability to break into debugger on unit test failure (gh-890)
 - Russian translations update (gh-897)
 - Add Python 3.10 to test matrix (gh-899)
+- Added support for Django 4.0 (gh-898)
 
 3.0.0 (2021-04-16)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -38,12 +38,13 @@ django-simple-history stores Django model state on every create/update/delete.
 
 This app supports the following combinations of Django and Python:
 
-==========  =======================
+==========  ========================
   Django      Python
 ==========  ========================
 2.2         3.6, 3.7, 3.8, 3.9
 3.1         3.6, 3.7, 3.8, 3.9
 3.2         3.6, 3.7, 3.8, 3.9, 3.10
+4.0         3.8, 3.9, 3.10
 ==========  ========================
 
 Getting Help

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -262,7 +262,8 @@ Using custom OneToOneFields
 If you are using a custom OneToOneField that has additional arguments and receiving
 the the following ``TypeError``::
 
-..
+.. code=block:: python
+
     TypeError: __init__() got an unexpected keyword argument
 
 This is because Django Simple History coerces ``OneToOneField`` into ``ForeignKey``

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ with open("README.rst") as readme, open("CHANGES.rst") as changes:
             "Framework :: Django :: 2.2",
             "Framework :: Django :: 3.1",
             "Framework :: Django :: 3.2",
+            "Framework :: Django :: 4.0",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3.6",
             "Programming Language :: Python :: 3.7",

--- a/simple_history/tests/tests/test_manager.py
+++ b/simple_history/tests/tests/test_manager.py
@@ -3,7 +3,7 @@ from operator import attrgetter
 
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError
-from django.test import TestCase, skipUnlessDBFeature, override_settings
+from django.test import TestCase, override_settings, skipUnlessDBFeature
 
 from ..models import Document, Poll
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
     dj22: Django>=2.2,<2.3
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
-    dj40: Django>=4.0a1,<4.1
+    dj40: Django>=4.0rc1,<4.1
     djmain: https://github.com/django/django/tarball/main
     postgres: -rrequirements/postgres.txt
     mysql: -rrequirements/mysql.txt

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py{36,37,38,39}-dj{22,31}-{sqlite3,postgres,mysql,mariadb},
     py{36,37,38,39,310}-dj32-{sqlite3,postgres,mysql,mariadb},
-    py{38,39,310}-djmain-{sqlite3,postgres,mysql,mariadb},
+    py{38,39,310}-dj{40,main}-{sqlite3,postgres,mysql,mariadb},
     docs,
     lint
 
@@ -19,6 +19,7 @@ DJANGO =
     2.2: dj22
     3.1: dj31
     3.2: dj32
+    4.0: dj40
     main: djmain
 
 [flake8]
@@ -33,6 +34,7 @@ deps =
     dj22: Django>=2.2,<2.3
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0a1,<4.1
     djmain: https://github.com/django/django/tarball/main
     postgres: -rrequirements/postgres.txt
     mysql: -rrequirements/mysql.txt


### PR DESCRIPTION
## Description
Added Django 4.0 support to test configs (GH and Tox) docs, and classifiers. 

## Motivation and Context
Django 4.0 is now in alpha and project can now test against that version to confirm compatibility. 

## How Has This Been Tested?
Tested locally with new Django4.0 environment with python 3.9 and sqlite. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `make format` command to format my code. Yes, but it failed due to unrelated changes. 
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
