### PR TITLE
Passing multiple template names to the templating engine. Django will…

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -20,8 +20,6 @@ SIMPLE_HISTORY_EDIT = getattr(settings, "SIMPLE_HISTORY_EDIT", False)
 
 
 class SimpleHistoryAdmin(admin.ModelAdmin):
-    object_history_template = "simple_history/object_history.html"
-    object_history_form_template = "simple_history/object_history_form.html"
 
     def get_urls(self):
         """Returns the additional urls used by the Reversion admin."""
@@ -94,7 +92,12 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context.update(extra_context or {})
         extra_kwargs = {}
         return self.render_history_view(
-            request, self.object_history_template, context, **extra_kwargs
+            request, [
+                "admin/%s/%s/object_history.html" % (app_label, opts.model_name),
+                "admin/%s/object_history.html" % app_label,
+                "admin/object_history.html",
+                "simple_history/object_history.html"
+            ], context, **extra_kwargs
         )
 
     def history_view_title(self, obj):
@@ -208,7 +211,13 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context.update(extra_context or {})
         extra_kwargs = {}
         return self.render_history_view(
-            request, self.object_history_form_template, context, **extra_kwargs
+            request, [
+                "admin/%s/%s/object_history_form.html" % (original_opts.app_label,
+                                                          model_name),
+                "admin/%s/object_history_form.html" % original_opts.app_label,
+                "admin/object_history_form.html",
+                "simple_history/object_history_form.html"
+            ], context, **extra_kwargs
         )
 
     def history_form_view_title(self, obj):


### PR DESCRIPTION
## Description 
This passes the Django default admin template override paths to the views in order so that a user can override the django admin templates used in this project.

## Related Issue
This addresses #919 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested with a Django app to override the `object_history.html` template per the Django documentation

## Screenshots (if appropriate):

## Types of changes
This change does not introduce any breaking changes in any version of Django >= 1.10. It allows the end user implementing this library to implement custom templates in their own project per Django documentation: https://docs.djangoproject.com/en/dev/ref/contrib/admin/#overriding-admin-templates

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
