### PR TITLE
Fix diff_against on model with non-editable fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -82,6 +82,7 @@ Authors
 - Martin Bachwerk
 - Marty Alchin
 - Matheus Cansian (`mscansian <https://github.com/mscansian>`_)
+- Matthew Somerville (`dracos <https://github.com/dracos>`_)
 - Mauricio de Abreu Antunes
 - Maxim Zemskov (`MaximZemskov <https://github.com/MaximZemskov>`_)
 - Micah Denbraver

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Full list of changes:
 - Add Python 3.10 to test matrix (gh-899)
 - Added support for Django 4.0 (gh-898)
 - Dropped support for Python 3.6, which reached end-of-life on 2021-12-23 (gh-946).
+- Fix bug with ``history.diff_against`` with non-editable fields (gh-923)
 
 3.0.0 (2021-04-16)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -637,7 +637,9 @@ class HistoricalChanges:
             excluded_fields = set()
 
         if included_fields is None:
-            included_fields = {f.name for f in old_history.instance_type._meta.fields}
+            included_fields = {
+                f.name for f in old_history.instance_type._meta.fields if f.editable
+            }
 
         fields = set(included_fields).difference(excluded_fields)
 

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -25,6 +25,14 @@ class Poll(models.Model):
         return reverse("poll-detail", kwargs={"pk": self.pk})
 
 
+class PollWithNonEditableField(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    modified = models.DateTimeField(auto_now=True, editable=False)
+
+    history = HistoricalRecords()
+
+
 class PollWithUniqueQuestion(models.Model):
     question = models.CharField(max_length=200, unique=True)
     pub_date = models.DateTimeField("date published")

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -78,6 +78,7 @@ from ..models import (
     Place,
     Poll,
     PollInfo,
+    PollWithNonEditableField,
     PollWithExcludedFieldsWithDefaults,
     PollWithExcludedFKField,
     PollWithExcludeFields,
@@ -694,6 +695,18 @@ class HistoricalRecordsTest(TestCase):
 
         with self.assertNumQueries(0):
             delta = new_record.diff_against(old_record, included_fields=["question"])
+        self.assertEqual(delta.changed_fields, ["question"])
+        self.assertEqual(len(delta.changes), 1)
+
+    def test_history_diff_with_non_editable_field(self):
+        p = PollWithNonEditableField.objects.create(
+            question="what's up?", pub_date=today
+        )
+        p.question = "what's up, man?"
+        p.save()
+        new_record, old_record = p.history.all()
+        with self.assertNumQueries(0):
+            delta = new_record.diff_against(old_record)
         self.assertEqual(delta.changed_fields, ["question"])
         self.assertEqual(len(delta.changes), 1)
 


### PR DESCRIPTION
## Description

#776 improved the performance of `diff_against` by setting `fields` directly to the fields of the instance. But `model_to_dict` ignores non-editable fields, which leads to an error when it loops over `fields` and can't fetch the non-editable fields.

I have added a test that fails without my change to ignore non-editable fields.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
