### PR TITLE
test against django 4.0 proper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,21 +12,21 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.1', '3.2', '4.0rc1', 'main']
+        django-version: ['2.2', '3.1', '3.2', '4.0', 'main']
 
         exclude:
           - python-version: '3.6'
+            django-version: '4.0'
+          - python-version: '3.6'
             django-version: 'main'
+          - python-version: '3.7'
+            django-version: '4.0'
           - python-version: '3.7'
             django-version: 'main'
           - python-version: '3.10'
             django-version: '2.2'
           - python-version: '3.10'
             django-version: '3.1'
-          - python-version: '3.6'
-            django-version: '4.0b1'
-          - python-version: '3.7'
-            django-version: '4.0b1'
 
     services:
 

--- a/simple_history/registry_tests/tests.py
+++ b/simple_history/registry_tests/tests.py
@@ -6,7 +6,7 @@ from io import StringIO
 from django.apps import apps
 from django.contrib.auth import get_user_model
 from django.core import management
-from django.test import TestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 
 from simple_history import exceptions, register
 
@@ -215,7 +215,7 @@ class TestCustomAttrOneToOneField(TestCase):
 
 
 @override_settings(MIGRATION_MODULES={})
-class TestMigrate(TestCase):
+class TestMigrate(TransactionTestCase):
     def test_makemigration_command(self):
         management.call_command(
             "makemigrations", "migration_test_app", stdout=StringIO()

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
     dj22: Django>=2.2,<2.3
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
-    dj40: Django>=4.0rc1,<4.1
+    dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/tarball/main
     postgres: -rrequirements/postgres.txt
     mysql: -rrequirements/mysql.txt


### PR DESCRIPTION
We were testing in ci against django 4.0rc1 and not django 4.0.  There was new code in djmain that caused one of our tests to fail.

This closes #937 