### PR TITLE
Make leaving change reason customizable via method overriding.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,6 +14,7 @@ Authors
 - Adnan Umer (`uadnan <https://github.com/uadnan>`_)
 - Aleksey Kladov
 - Alexander Anikeev
+- `Amartis <https://github.com/amartis>`_
 - Amanda Ng (`AmandaCLNg <https://github.com/AmandaCLNg>`_)
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - Benjamin Mampaey (`bmampaey <https://github.com/bmampaey>`_)

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,8 +14,8 @@ Authors
 - Adnan Umer (`uadnan <https://github.com/uadnan>`_)
 - Aleksey Kladov
 - Alexander Anikeev
-- `Amartis <https://github.com/amartis>`_
 - Amanda Ng (`AmandaCLNg <https://github.com/AmandaCLNg>`_)
+- `Amartis <https://github.com/amartis>`_
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - Benjamin Mampaey (`bmampaey <https://github.com/bmampaey>`_)
 - `bradford281 <https://github.com/bradford281>`_

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -493,7 +493,7 @@ class HistoricalRecords:
         using = using if self.use_base_model_db else None
         history_date = getattr(instance, "_history_date", timezone.now())
         history_user = self.get_history_user(instance)
-        history_change_reason = get_change_reason_from_object(instance)
+        history_change_reason = self.get_change_reason_for_object(instance)
         manager = getattr(instance, self.manager_name)
 
         attrs = {}

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -482,6 +482,13 @@ class HistoricalRecords:
         else:
             self.create_historical_record(instance, "-", using=using)
 
+    def get_change_reason_for_object(self, instance):
+        """
+        Get change reason for object.
+        Customize this method to automatically fill change reason from context
+        """
+        return get_change_reason_from_object(instance)
+
     def create_historical_record(self, instance, history_type, using=None):
         using = using if self.use_base_model_db else None
         history_date = getattr(instance, "_history_date", timezone.now())

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -482,11 +482,18 @@ class HistoricalRecords:
         else:
             self.create_historical_record(instance, "-", using=using)
 
+    def get_change_reason_for_object(self, instance):
+        """
+        Get change reason for object.
+        Customize this method to automatically fill change reason from context
+        """
+        return get_change_reason_from_object(instance)
+
     def create_historical_record(self, instance, history_type, using=None):
         using = using if self.use_base_model_db else None
         history_date = getattr(instance, "_history_date", timezone.now())
         history_user = self.get_history_user(instance)
-        history_change_reason = get_change_reason_from_object(instance)
+        history_change_reason = self.get_change_reason_for_object(instance)
         manager = getattr(instance, self.manager_name)
 
         attrs = {}

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -482,18 +482,11 @@ class HistoricalRecords:
         else:
             self.create_historical_record(instance, "-", using=using)
 
-    def get_change_reason_for_object(self, instance):
-        """
-        Get change reason for object.
-        Customize this method to automatically fill change reason from context
-        """
-        return get_change_reason_from_object(instance)
-
     def create_historical_record(self, instance, history_type, using=None):
         using = using if self.use_base_model_db else None
         history_date = getattr(instance, "_history_date", timezone.now())
         history_user = self.get_history_user(instance)
-        history_change_reason = self.get_change_reason_for_object(instance)
+        history_change_reason = get_change_reason_from_object(instance)
         manager = getattr(instance, self.manager_name)
 
         attrs = {}


### PR DESCRIPTION
Make leaving change reason customizable via method overriding.

## Description
I wanted to leave the request info as change reason for each history change record automatically.
Previous code structure didn't support this.
So I did minor code refactoring.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
