### PR TITLE
Make change reason customizable with overriding.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,7 @@ Authors
 - Aleksey Kladov
 - Alexander Anikeev
 - Amanda Ng (`AmandaCLNg <https://github.com/AmandaCLNg>`_)
+- Amartis Gladius (`Amartis <https://github.com/amartis>`_)
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - Benjamin Mampaey (`bmampaey <https://github.com/bmampaey>`_)
 - `bradford281 <https://github.com/bradford281>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Full list of changes:
 - Fix bug with ``history.diff_against`` with non-editable fields (gh-923)
 - Dropped support for Django 3.1 (gh-952)
 - RecordModels now support a ``no_db_index`` setting, to drop indices in historical models, default stays the same (gh-720)
+- Support change reason formula feature. Change reason formula can be defined by overriding ``get_change_reason_for_object`` method after subclassing ``HistoricalRecords``
 
 3.0.0 (2021-04-16)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -541,11 +541,18 @@ class HistoricalRecords:
         else:
             self.create_historical_record(instance, "-", using=using)
 
+    def get_change_reason_for_object(self, instance, history_type, using):
+        """
+        Get change reason for object.
+        Customize this method to automatically fill change reason from context. 
+        """
+        return get_change_reason_from_object(instance)
+
     def create_historical_record(self, instance, history_type, using=None):
         using = using if self.use_base_model_db else None
         history_date = getattr(instance, "_history_date", timezone.now())
         history_user = self.get_history_user(instance)
-        history_change_reason = get_change_reason_from_object(instance)
+        history_change_reason = self.get_change_reason_for_object(instance, history_type, using)
         manager = getattr(instance, self.manager_name)
 
         attrs = {}


### PR DESCRIPTION
Shortcoming of previous architecture:
Recording reason for change was only through manually setting to each object or through bulk_history_create.
So recording API request as reason automatically was hard to implement with this architecture.

Solution:
Getting change reason is now done through `HistoricalRecords` method `get_change_reason_for_object`.
And thus this method can be overriden in subclass to define custom behavior.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
