### PR TITLE
Removed n+1 query from bulk_create_with_history utility

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -112,6 +112,7 @@ Authors
 - Steven Buss (`sbuss <https://github.com/sbuss>`_)
 - Steven Klass
 - Tim Schilling (`tim-schilling <https://github.com/tim-schilling>`_)
+- Todd Wolfson (`twolfson <https://github.com/twolfson>`_)
 - Tommy Beadle (`tbeadle <https://github.com/tbeadle>`_)
 - Trey Hunner (`treyhunner <https://github.com/treyhunner>`_)
 - Ulysses Vilela

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 Unreleased
 ----------
 
+- Removed n+1 query from ``bulk_create_with_history`` utility (gh-975)
+
 
 3.1.0 (2022-04-09)
 ------------------

--- a/runtests.py
+++ b/runtests.py
@@ -160,11 +160,9 @@ def main():
 
     tags = namespace.tag
     failures = DiscoverRunner(
-        debug_sql=True,
         failfast=bool(namespace.failfast), pdb=bool(namespace.pdb), tags=tags
     ).run_tests(["simple_history.tests"])
     failures |= DiscoverRunner(
-        debug_sql=True,
         failfast=bool(namespace.failfast), pdb=bool(namespace.pdb), tags=tags
     ).run_tests(["simple_history.registry_tests"])
     sys.exit(failures)

--- a/runtests.py
+++ b/runtests.py
@@ -160,9 +160,11 @@ def main():
 
     tags = namespace.tag
     failures = DiscoverRunner(
+        debug_sql=True,
         failfast=bool(namespace.failfast), pdb=bool(namespace.pdb), tags=tags
     ).run_tests(["simple_history.tests"])
     failures |= DiscoverRunner(
+        debug_sql=True,
         failfast=bool(namespace.failfast), pdb=bool(namespace.pdb), tags=tags
     ).run_tests(["simple_history.registry_tests"])
     sys.exit(failures)

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
+from django.test import tag
 
 from simple_history.exceptions import AlternativeManagerError, NotHistoricalModelError
 from simple_history.tests.models import (
@@ -71,6 +72,7 @@ class BulkCreateWithHistoryTestCase(TestCase):
             ),
         ]
 
+    @tag('only')
     def test_bulk_create_history(self):
         with self.assertNumQueries(3):
             bulk_create_with_history(self.data, Poll)

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -188,6 +188,20 @@ class BulkCreateWithHistoryTestCase(TestCase):
         self.assertEqual(PollWithUniqueQuestion.objects.count(), 2)
         self.assertEqual(PollWithUniqueQuestion.history.count(), 2)
 
+    @tag('only')
+    def test_bulk_create_history_with_no_ids_return(self):
+        objects = [Place(name="Place 1"), Place(name="Place 2"), Place(name="Place 3")]
+
+        _bulk_create = Place._default_manager.bulk_create
+
+        def mock_bulk_create(*args, **kwargs):
+            _bulk_create(*args, **kwargs)
+            return [Place(name="Place 1"), Place(name="Place 2"), Place(name="Place 3")]
+
+        with patch.object(Place._default_manager, "bulk_create", side_effect=mock_bulk_create):
+            with self.assertNumQueries(2):
+                result = bulk_create_with_history(objects, Place)
+                self.assertEqual(result, objects)
 
 class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
     def setUp(self):
@@ -238,31 +252,28 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
         self.assertEqual(Poll.objects.count(), 0)
         self.assertEqual(Poll.history.count(), 0)
 
-    @tag('only')
+    # @tag('only')
     @patch("simple_history.utils.get_history_manager_for_model")
     def test_bulk_create_no_ids_return(self, hist_manager_mock):
-        objects = [Place(name="Place 1")]
-        with patch.object(Place._default_manager, "bulk_create", return_value=[Place(name="Place 1")]):
+        objects = [Place(name="Place 1"), Place(name="Place 2"), Place(name="Place 3")]
 
-        model = Mock(
-            _default_manager=Mock(
-                bulk_create=Mock(),
-                filter=Mock(return_value=Mock(
-                    order_by=Mock(return_value=objects)
-                )),
-            ),
-            _meta=Mock(get_fields=Mock(return_value=[])),
-        )
-        with self.assertNumQueries(2):
-            result = bulk_create_with_history(objects, model)
-        self.assertEqual(result, objects)
-        hist_manager_mock().bulk_history_create.assert_called_with(
-            objects,
-            batch_size=None,
-            default_user=None,
-            default_change_reason=None,
-            default_date=None,
-        )
+        _bulk_create = Place._default_manager.bulk_create
+
+        def mock_bulk_create(*args, **kwargs):
+            _bulk_create(*args, **kwargs)
+            return [Place(name="Place 1"), Place(name="Place 2"), Place(name="Place 3")]
+
+        with patch.object(Place._default_manager, "bulk_create", side_effect=mock_bulk_create):
+            with self.assertNumQueries(2):
+                result = bulk_create_with_history(objects, Place)
+            self.assertEqual(result, objects)
+            hist_manager_mock().bulk_history_create.assert_called_with(
+                objects,
+                batch_size=None,
+                default_user=None,
+                default_change_reason=None,
+                default_date=None,
+            )
 
 
 class BulkCreateWithManyToManyField(TestCase):

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -186,7 +186,6 @@ class BulkCreateWithHistoryTestCase(TestCase):
         self.assertEqual(PollWithUniqueQuestion.objects.count(), 2)
         self.assertEqual(PollWithUniqueQuestion.history.count(), 2)
 
-    @tag('only')
     def test_bulk_create_history_with_no_ids_return(self):
         pub_date = timezone.now()
         objects = [
@@ -265,28 +264,27 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
         self.assertEqual(Poll.objects.count(), 0)
         self.assertEqual(Poll.history.count(), 0)
 
-    # @tag('only')
     @patch("simple_history.utils.get_history_manager_for_model")
     def test_bulk_create_no_ids_return(self, hist_manager_mock):
-        objects = [Place(name="Place 1"), Place(name="Place 2"), Place(name="Place 3")]
-
-        _bulk_create = Place._default_manager.bulk_create
-
-        def mock_bulk_create(*args, **kwargs):
-            _bulk_create(*args, **kwargs)
-            return [Place(name="Place 1"), Place(name="Place 2"), Place(name="Place 3")]
-
-        with patch.object(Place._default_manager, "bulk_create", side_effect=mock_bulk_create):
-            with self.assertNumQueries(2):
-                result = bulk_create_with_history(objects, Place)
-            self.assertEqual(result, objects)
-            hist_manager_mock().bulk_history_create.assert_called_with(
-                objects,
-                batch_size=None,
-                default_user=None,
-                default_change_reason=None,
-                default_date=None,
-            )
+        objects = [Place(id=1, name="Place 1")]
+        model = Mock(
+            _default_manager=Mock(
+                bulk_create=Mock(return_value=[Place(name="Place 1")]),
+                filter=Mock(return_value=Mock(
+                    order_by=Mock(return_value=objects)
+                )),
+            ),
+            _meta=Mock(get_fields=Mock(return_value=[])),
+        )
+        result = bulk_create_with_history(objects, model)
+        self.assertEqual(result, objects)
+        hist_manager_mock().bulk_history_create.assert_called_with(
+            objects,
+            batch_size=None,
+            default_user=None,
+            default_change_reason=None,
+            default_date=None,
+        )
 
 
 class BulkCreateWithManyToManyField(TestCase):

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -72,7 +72,8 @@ class BulkCreateWithHistoryTestCase(TestCase):
         ]
 
     def test_bulk_create_history(self):
-        bulk_create_with_history(self.data, Poll)
+        with self.assertNumQueries(3):
+            bulk_create_with_history(self.data, Poll)
 
         self.assertEqual(Poll.objects.count(), 5)
         self.assertEqual(Poll.history.count(), 5)

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -190,12 +190,13 @@ class BulkCreateWithHistoryTestCase(TestCase):
 
     @tag('only')
     def test_bulk_create_history_with_no_ids_return(self):
+        pub_date = timezone.now()
         objects = [
-            Poll(question="Question 1", pub_date=timezone.now()),
-            Poll(question="Question 2", pub_date=timezone.now()),
-            Poll(question="Question 3", pub_date=timezone.now()),
-            Poll(question="Question 4", pub_date=timezone.now()),
-            Poll(question="Question 5", pub_date=timezone.now()),
+            Poll(question="Question 1", pub_date=pub_date),
+            Poll(question="Question 2", pub_date=pub_date),
+            Poll(question="Question 3", pub_date=pub_date),
+            Poll(question="Question 4", pub_date=pub_date),
+            Poll(question="Question 5", pub_date=pub_date),
         ]
 
         _bulk_create = Poll._default_manager.bulk_create
@@ -203,16 +204,16 @@ class BulkCreateWithHistoryTestCase(TestCase):
         def mock_bulk_create(*args, **kwargs):
             _bulk_create(*args, **kwargs)
             return [
-                Poll(question="Question 1", pub_date=timezone.now()),
-                Poll(question="Question 2", pub_date=timezone.now()),
-                Poll(question="Question 3", pub_date=timezone.now()),
-                Poll(question="Question 4", pub_date=timezone.now()),
-                Poll(question="Question 5", pub_date=timezone.now()),
+                Poll(question="Question 1", pub_date=pub_date),
+                Poll(question="Question 2", pub_date=pub_date),
+                Poll(question="Question 3", pub_date=pub_date),
+                Poll(question="Question 4", pub_date=pub_date),
+                Poll(question="Question 5", pub_date=pub_date),
             ]
 
         with patch.object(Poll._default_manager, "bulk_create",
                           side_effect=mock_bulk_create):
-            with self.assertNumQueries(4):
+            with self.assertNumQueries(3):
                 result = bulk_create_with_history(objects, Poll)
             self.assertEqual(result, objects)
 

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -72,7 +72,7 @@ class BulkCreateWithHistoryTestCase(TestCase):
             ),
         ]
 
-    @tag('only')
+    # @tag('only')
     def test_bulk_create_history(self):
         bulk_create_with_history(self.data, Poll)
 
@@ -190,18 +190,32 @@ class BulkCreateWithHistoryTestCase(TestCase):
 
     @tag('only')
     def test_bulk_create_history_with_no_ids_return(self):
-        objects = [Place(name="Place 1"), Place(name="Place 2"), Place(name="Place 3")]
+        objects = [
+            Poll(question="Question 1", pub_date=timezone.now()),
+            Poll(question="Question 2", pub_date=timezone.now()),
+            Poll(question="Question 3", pub_date=timezone.now()),
+            Poll(question="Question 4", pub_date=timezone.now()),
+            Poll(question="Question 5", pub_date=timezone.now()),
+        ]
 
-        _bulk_create = Place._default_manager.bulk_create
+        _bulk_create = Poll._default_manager.bulk_create
 
         def mock_bulk_create(*args, **kwargs):
             _bulk_create(*args, **kwargs)
-            return [Place(name="Place 1"), Place(name="Place 2"), Place(name="Place 3")]
+            return [
+                Poll(question="Question 1", pub_date=timezone.now()),
+                Poll(question="Question 2", pub_date=timezone.now()),
+                Poll(question="Question 3", pub_date=timezone.now()),
+                Poll(question="Question 4", pub_date=timezone.now()),
+                Poll(question="Question 5", pub_date=timezone.now()),
+            ]
 
-        with patch.object(Place._default_manager, "bulk_create", side_effect=mock_bulk_create):
-            with self.assertNumQueries(2):
-                result = bulk_create_with_history(objects, Place)
-                self.assertEqual(result, objects)
+        with patch.object(Poll._default_manager, "bulk_create",
+                          side_effect=mock_bulk_create):
+            with self.assertNumQueries(4):
+                result = bulk_create_with_history(objects, Poll)
+            self.assertEqual(result, objects)
+
 
 class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
     def setUp(self):

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -5,7 +5,6 @@ from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
-from django.test import tag
 
 from simple_history.exceptions import AlternativeManagerError, NotHistoricalModelError
 from simple_history.tests.models import (
@@ -72,7 +71,6 @@ class BulkCreateWithHistoryTestCase(TestCase):
             ),
         ]
 
-    # @tag('only')
     def test_bulk_create_history(self):
         bulk_create_with_history(self.data, Poll)
 

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -208,8 +208,9 @@ class BulkCreateWithHistoryTestCase(TestCase):
                 Poll(question="Question 5", pub_date=pub_date),
             ]
 
-        with patch.object(Poll._default_manager, "bulk_create",
-                          side_effect=mock_bulk_create):
+        with patch.object(
+            Poll._default_manager, "bulk_create", side_effect=mock_bulk_create
+        ):
             with self.assertNumQueries(3):
                 result = bulk_create_with_history(objects, Poll)
             self.assertEqual(result, objects)
@@ -270,9 +271,7 @@ class BulkCreateWithHistoryTransactionTestCase(TransactionTestCase):
         model = Mock(
             _default_manager=Mock(
                 bulk_create=Mock(return_value=[Place(name="Place 1")]),
-                filter=Mock(return_value=Mock(
-                    order_by=Mock(return_value=objects)
-                )),
+                filter=Mock(return_value=Mock(order_by=Mock(return_value=objects))),
             ),
             _meta=Mock(get_fields=Mock(return_value=[])),
         )

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -101,7 +101,6 @@ def bulk_create_with_history(
         objs_with_id = model_manager.bulk_create(
             objs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
         )
-        print('aaa', objs_with_id[0].pk)
         if objs_with_id and objs_with_id[0].pk and not ignore_conflicts:
             second_transaction_required = False
             history_manager.bulk_history_create(

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -111,7 +111,6 @@ def bulk_create_with_history(
                 default_change_reason=default_change_reason,
                 default_date=default_date,
             )
-            print('ran here')
     if second_transaction_required:
         with transaction.atomic(savepoint=False):
             # Generate a common query to avoid n+1 selections

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -101,17 +101,17 @@ def bulk_create_with_history(
         objs_with_id = model_manager.bulk_create(
             objs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
         )
-        print('aaa', objs_with_id.__class__)
-        # TODO: In tests, once this is all sorted, make `bulk_create` return unaltered objects and see if that works
-        # if objs_with_id and objs_with_id[0].pk and not ignore_conflicts:
-        #     second_transaction_required = False
-        #     history_manager.bulk_history_create(
-        #         objs_with_id,
-        #         batch_size=batch_size,
-        #         default_user=default_user,
-        #         default_change_reason=default_change_reason,
-        #         default_date=default_date,
-        #     )
+        print('aaa', objs_with_id[0].pk)
+        if objs_with_id and objs_with_id[0].pk and not ignore_conflicts:
+            second_transaction_required = False
+            history_manager.bulk_history_create(
+                objs_with_id,
+                batch_size=batch_size,
+                default_user=default_user,
+                default_change_reason=default_change_reason,
+                default_date=default_date,
+            )
+            print('ran here')
     if second_transaction_required:
         with transaction.atomic(savepoint=False):
             # Generate a common query to avoid n+1 selections

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -133,11 +133,12 @@ def bulk_create_with_history(
                 obj_when_list.append(When(**attributes, then=i))
             obj_list = (
                 list(
-                    model_manager
-                    .filter(cumulative_filter)
-                    .order_by(Case(*obj_when_list))
+                    model_manager.filter(cumulative_filter).order_by(
+                        Case(*obj_when_list)
+                    )
                 )
-                if objs_with_id else []
+                if objs_with_id
+                else []
             )
             history_manager.bulk_history_create(
                 obj_list,

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -101,15 +101,15 @@ def bulk_create_with_history(
         objs_with_id = model_manager.bulk_create(
             objs, batch_size=batch_size, ignore_conflicts=ignore_conflicts
         )
-        if objs_with_id and objs_with_id[0].pk and not ignore_conflicts:
-            second_transaction_required = False
-            history_manager.bulk_history_create(
-                objs_with_id,
-                batch_size=batch_size,
-                default_user=default_user,
-                default_change_reason=default_change_reason,
-                default_date=default_date,
-            )
+        # if objs_with_id and objs_with_id[0].pk and not ignore_conflicts:
+        #     second_transaction_required = False
+        #     history_manager.bulk_history_create(
+        #         objs_with_id,
+        #         batch_size=batch_size,
+        #         default_user=default_user,
+        #         default_change_reason=default_change_reason,
+        #         default_date=default_date,
+        #     )
     if second_transaction_required:
         obj_list = []
         with transaction.atomic(savepoint=False):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Updated section of `bulk_create_with_history` which doesn't have `ids` in response from database to consolidate `n+1` lookups into 1 lookup
- Added test to reproduce issue (old version made 7 queries, new makes 3 (INSERT normal, SELECT WHERE for ids, INSERT history))

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/jazzband/django-simple-history/issues/974

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

For databases which lack ids in responses, there was a significant amount of additional queries being run. This resolves that issue by consolidating the number of queries

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Yes, please see changes in the test suite

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
