### PR TITLE
[fix] add fallback_version to scm settings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("README.rst") as readme, open("CHANGES.rst") as changes:
             "local_scheme": "node-and-date",
             "relative_to": __file__,
             "root": ".",
+            "fallback_version": "0.0.0",
         },
         setup_requires=["setuptools_scm"],
         description="Store model history and view/revert changes from admin site.",


### PR DESCRIPTION
## Description
setuptools_scm [https://pypi.org/project/setuptools-scm/] is causing issues if you are trying to install this package directly from a `zip` or `tar.gz`.
That is expected as there is no metadata in the archive file, and the following error will raise:
```
      LookupError: setuptools-scm was unable to detect version for /tmp/pip-req-build-plm5aze3.
```

This is probably not affecting a lot of people but there is situation where it's not possible to use git to install the package, or wait for the latest version to be on pypi.

# Alternative solutions
* Use env `SETUPTOOLS_SCM_FALLBACK_VERSION`
* Use git archives: https://pypi.org/project/setuptools-scm-git-archive/

## Related Issue
ref: https://github.com/jazzband/django-simple-history/issues/960#issuecomment-1098147525
ref: https://github.com/pypa/setuptools_scm/issues/409

## Proposed Solution
A quick workaround is using `fallback_version` see attached PR,
there is certainly more elegant solution, hopefully one that could still use the latest tag.

