### PR TITLE
Replaces count by exists in populate_history command

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,6 +39,7 @@ Authors
 - Edouard Richard (`vied12 <https://github.com/vied12>` _)
 - Eduardo Cuducos
 - Erik van Widenfelt (`erikvw <https://github.com/erikvw>`_)
+- Fábio Capuano (`fabiocapsouza <https://github.com/fabiocapsouza`_)
 - Filipe Pina (@fopina)
 - Florian Eßer
 - François Martin (`martinfrancois <https://github.com/martinfrancois>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 
+- Started using ``exists`` query instead of ``count`` in ``populate_history`` command (gh-982)
 
 3.1.1 (2022-04-23)
 ------------------

--- a/simple_history/management/commands/populate_history.py
+++ b/simple_history/management/commands/populate_history.py
@@ -156,7 +156,7 @@ class Command(BaseCommand):
 
     def _process(self, to_process, batch_size):
         for model, history_model in to_process:
-            if history_model.objects.count():
+            if history_model.objects.exists():
                 self.stderr.write(
                     "{msg} {model}\n".format(
                         msg=self.EXISTING_HISTORY_FOUND, model=model


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replaces a `count()` query in `populate_history` command by `exists()`


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/jazzband/django-simple-history/issues/922

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `populate_history` command checks if historical records exist for each model. However, this check uses a `count` query that can be expensive if the historical table is large. An `exists` query serves this purpose and is much faster to run.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran all tests using the runtests.py script and sqlite3 database.

The `populate_history` command is already tested by TestPopulateHistory TestCase and covers this change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [X] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
