### PR TITLE
[issue-983] querying history, convert to instance, chase foreign key on history_date

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -673,7 +673,7 @@ class HistoricForwardManyToOneDescriptor(ForwardManyToOneDescriptor):
                 None,
             )
             if history and histmgr:
-                return histmgr.as_of(history._as_of)
+                return histmgr.as_of(getattr(history, "_as_of", history.history_date))
         return super().get_queryset(**hints)
 
 
@@ -708,7 +708,9 @@ class HistoricReverseManyToOneDescriptor(ReverseManyToOneDescriptor):
                         None,
                     )
                     if history and histmgr:
-                        queryset = histmgr.as_of(history._as_of)
+                        queryset = histmgr.as_of(
+                            getattr(history, "_as_of", history.history_date)
+                        )
                     else:
                         queryset = super().get_queryset()
                     return self._apply_rel_filters(queryset)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -2012,3 +2012,16 @@ class HistoricForeignKeyTest(TestCase):
             to_historic(ot1), TestOrganizationWithHistory.history.model
         )
         self.assertIsNone(to_historic(org))
+
+        # test querying directly from the history table and converting
+        # to an instance, it should chase the foreign key properly
+        # in this case if _as_of is not present we use the history_date
+        # https://github.com/jazzband/django-simple-history/issues/983
+        pt1h = TestHistoricParticipanToHistoricOrganization.history.all()[0]
+        pt1i = pt1h.instance
+        self.assertEqual(pt1i.organization.name, "modified")
+        pt1h = TestHistoricParticipanToHistoricOrganization.history.all().order_by(
+            "history_date"
+        )[0]
+        pt1i = pt1h.instance
+        self.assertEqual(pt1i.organization.name, "original")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This fixes an issue whereby:

1. User queries history directly.
2. User converts Historical<> to instance with instance property.
3. Original query (from 3.1) was not with history.as_of so it did not have _as_of property
4. instance failed

The fix:

When _history._as_of is not present use the history.history_date field instead
when chasing foreign keys.

This closes #983 

In the end, if you did not query history with as_of, and you end up with a historical instance, if you call .instance on it, the HistoricalForeignKey chasers will use a fallback of the history_date of the record that made the instance when chasing relations! This was an easy fix and an easy win, and makes django-simple-history more powerful.