### PR TITLE
Fix double colon

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -260,7 +260,7 @@ Using custom OneToOneFields
 ---------------------------
 
 If you are using a custom OneToOneField that has additional arguments and receiving
-the the following ``TypeError``::
+the the following ``TypeError``:
 
 .. code=block:: python
 


### PR DESCRIPTION
Double colon causes ".. code=block:: python" to be displayed in the docs

<!--- Provide a general summary of your changes in the Title above -->

## Description

Trivial change - typo in docs

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/60589645/169629460-023e8b6b-3c1d-4372-bec3-41b11c0f05a8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
