### PR TITLE
Call make dist in the Release action. Fixes #987

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Build package
         run: |
-          python setup.py --version
-          python setup.py sdist --format=gztar bdist_wheel
+          make dist
+
           twine check dist/*
 
       - name: Upload packages to Jazzband


### PR DESCRIPTION
Try to fix #987 by executing `make dist` from within the release action on GitHub.

May not work due to gpg failures. I don't have a way of testing it.

## Description
<!--- Describe your changes in detail -->

## Related Issue
https://github.com/jazzband/django-simple-history/issues/987

## Motivation and Context
To avoid missing wheel packages on PyPI and unify the build process regardless in which environment it happens.

## How Has This Been Tested?
It hasn't been tested.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
