### PR TITLE
Fix code block in docs for Using custom OneToOneFields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -18,6 +18,7 @@ Authors
 - Amartis Gladius (`Amartis <https://github.com/amartis>`_)
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - Benjamin Mampaey (`bmampaey <https://github.com/bmampaey>`_)
+- Bheesham Persaud (`bheesham <https://github.com/bheesham>`_)
 - `bradford281 <https://github.com/bradford281>`_
 - Brian Armstrong (`barm <https://github.com/barm>`_)
 - Buddy Lindsey, Jr.

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -262,8 +262,6 @@ Using custom OneToOneFields
 If you are using a custom OneToOneField that has additional arguments and receiving
 the the following ``TypeError``::
 
-.. code=block:: python
-
     TypeError: __init__() got an unexpected keyword argument
 
 This is because Django Simple History coerces ``OneToOneField`` into ``ForeignKey``


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes a typo in the documentation.

## Related Issue
https://github.com/jazzband/django-simple-history/issues/1010

## Motivation and Context

It fixes some formatting in the generated docs.

## How Has This Been Tested?

I viewed the file on GitHub, currently available here: https://github.com/bheesham/django-simple-history/blob/fix-code-block-documentation/docs/common_issues.rst#using-custom-onetoonefields

## Screenshots (if appropriate):
![Screenshot_20220706_233518](https://user-images.githubusercontent.com/171007/177685254-bee76b1b-a94a-4af1-8bea-8aef3c6daa3b.png)

See bug report for screenshot of what it was like before: https://github.com/jazzband/django-simple-history/issues/1010

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have run the `pre-commit run` command to format and lint.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes. -- None required.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [X] I have added my change to `CHANGES.rst` -- there was already a line in there for fixing typos in the docs.
- [x] All new and existing tests passed. -- just documentation change so I'm (probably) not breaking anything, some tests failed but that's because I don't have certain things installed.
