### PR TITLE
Use exists query instead of count in clean-duplicate-history command.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,6 +16,7 @@ Authors
 - Alexander Anikeev
 - Amanda Ng (`AmandaCLNg <https://github.com/AmandaCLNg>`_)
 - Amartis Gladius (`Amartis <https://github.com/amartis>`_)
+- Anton Kulikov (`bigtimecriminal <https://github.com/bigtimecriminal>`_)
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - Benjamin Mampaey (`bmampaey <https://github.com/bmampaey>`_)
 - `bradford281 <https://github.com/bradford281>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 
+- Started using ``exists`` query instead of ``count`` in ``clean-duplicate_history`` command
 - Fixed typos in the docs
 - Removed n+1 query from ``bulk_create_with_history`` utility (gh-975)
 - Started using ``exists`` query instead of ``count`` in ``populate_history`` command (gh-982)

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -66,9 +66,10 @@ class Command(populate_history.Command):
             m_qs = history_model.objects
             if stop_date:
                 m_qs = m_qs.filter(history_date__gte=stop_date)
-            found = m_qs.count()
-            self.log(f"{model} has {found} historical entries", 2)
-            if not found:
+            if self.verbosity >= 2:
+                found = m_qs.count()
+                self.log(f"{model} has {found} historical entries", 2)
+            if not m_qs.exists():
                 continue
 
             # Break apart the query so we can add additional filtering


### PR DESCRIPTION
## Description
Instead of using a nested `count` query in `clean-duplicate-history`, use `exists` unless we're at `verbose >= 2`

## Related Issue
https://github.com/jazzband/django-simple-history/issues/1014

## Motivation and Context
Removes costly query that only exists to log something out on a log that might not be called.

## How Has This Been Tested?
Ran all tests. Command is already being tested by test suite

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
