### PR TITLE
Fix `KeyError` when cleaning duplicate history

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,6 +38,7 @@ Authors
 - David Grochowski (`ThePumpingLemma <https://github.com/ThePumpingLemma>`_)
 - David Hite
 - David Smith
+- `ddabble <https://github.com/ddabble>`_
 - Dmytro Shyshov (`xahgmah <https://github.com/xahgmah>`_)
 - Edouard Richard (`vied12 <https://github.com/vied12>` _)
 - Eduardo Cuducos

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
 - Started using ``exists`` query instead of ``count`` in ``populate_history`` command (gh-982)
 - Add basic support for many-to-many fields (gh-399)
 - Added support for Django 4.1 (gh-1021)
+- Added ``tracked_fields`` attribute to historical models (gh-1038)
 
 3.1.1 (2022-04-23)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased
 - Add basic support for many-to-many fields (gh-399)
 - Added support for Django 4.1 (gh-1021)
 - Added ``tracked_fields`` attribute to historical models (gh-1038)
+- Fixed ``KeyError`` when running ``clean_duplicate_history`` on models with ``excluded_fields`` (gh-1038)
 
 3.1.1 (2022-04-23)
 ------------------

--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -155,11 +155,8 @@ class HistoryManager(models.Manager):
                 )
             )
         tmp = []
-        excluded_fields = getattr(self.model, "_history_excluded_fields", [])
 
-        for field in self.instance._meta.fields:
-            if field.name in excluded_fields:
-                continue
+        for field in self.model.tracked_fields:
             if isinstance(field, models.ForeignKey):
                 tmp.append(field.name + "_id")
             else:
@@ -263,8 +260,7 @@ class HistoryManager(models.Manager):
                 history_type=history_type,
                 **{
                     field.attname: getattr(instance, field.attname)
-                    for field in instance._meta.fields
-                    if field.name not in self.model._history_excluded_fields
+                    for field in self.model.tracked_fields
                 },
             )
             if hasattr(self.model, "history_relation"):

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -274,6 +274,7 @@ class HistoricalRecords:
             "__module__": self.module,
             "_history_excluded_fields": self.excluded_fields,
             "_history_m2m_fields": self.get_m2m_fields_from_model(model),
+            "tracked_fields": self.fields_included(model),
         }
 
         app_module = "%s.models" % model._meta.app_label

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -928,9 +928,7 @@ class HistoricalChanges:
 
         included_m2m_fields = {field.name for field in old_history._history_m2m_fields}
         if included_fields is None:
-            included_fields = {
-                f.name for f in old_history.instance_type._meta.fields if f.editable
-            }
+            included_fields = {f.name for f in old_history.tracked_fields if f.editable}
         else:
             included_m2m_fields = included_m2m_fields.intersection(included_fields)
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -71,6 +71,8 @@ def _history_user_setter(historical_instance, user):
 
 
 class HistoricalRecords:
+    DEFAULT_MODEL_NAME_PREFIX = "Historical"
+
     thread = context = LocalContext()  # retain thread for backwards compatibility
     m2m_models = {}
 
@@ -230,7 +232,7 @@ class HistoricalRecords:
 
     def get_history_model_name(self, model):
         if not self.custom_model_name:
-            return f"Historical{model._meta.object_name}"
+            return f"{self.DEFAULT_MODEL_NAME_PREFIX}{model._meta.object_name}"
         # Must be trying to use a custom history model name
         if callable(self.custom_model_name):
             name = self.custom_model_name(model._meta.object_name)

--- a/simple_history/tests/tests/test_commands.py
+++ b/simple_history/tests/tests/test_commands.py
@@ -410,6 +410,25 @@ class TestCleanDuplicateHistory(TestCase):
         )
         self.assertEqual(Poll.history.all().count(), 1)
 
+    def test_auto_cleanup_for_model_with_excluded_fields(self):
+        p = PollWithExcludeFields.objects.create(
+            question="Will this be deleted?", pub_date=datetime.now()
+        )
+        self.assertEqual(PollWithExcludeFields.history.all().count(), 1)
+        p.pub_date = p.pub_date + timedelta(days=1)
+        p.save()
+        self.assertEqual(PollWithExcludeFields.history.all().count(), 2)
+        out = StringIO()
+        management.call_command(
+            self.command_name, auto=True, stdout=out, stderr=StringIO()
+        )
+        self.assertEqual(
+            out.getvalue(),
+            "Removed 1 historical records for "
+            "<class 'simple_history.tests.models.PollWithExcludeFields'>\n",
+        )
+        self.assertEqual(PollWithExcludeFields.history.all().count(), 1)
+
 
 class TestCleanOldHistory(TestCase):
     command_name = "clean_old_history"

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -898,7 +898,7 @@ class GetPrevRecordAndNextRecordTestCase(TestCase):
 class CreateHistoryModelTests(unittest.TestCase):
     @staticmethod
     def create_history_model(model, inherited):
-        custom_model_name_prefix = "MockHistorical"
+        custom_model_name_prefix = f"Mock{HistoricalRecords.DEFAULT_MODEL_NAME_PREFIX}"
         records = HistoricalRecords(
             # Provide a custom history model name, to prevent name collisions
             # with existing historical models
@@ -912,7 +912,7 @@ class CreateHistoryModelTests(unittest.TestCase):
             from .. import models
 
             history_model = getattr(
-                models, f"Historical{model.__name__}"
+                models, f"{HistoricalRecords.DEFAULT_MODEL_NAME_PREFIX}{model.__name__}"
             )
             self.assertListEqual(
                 [field.name for field in history_model.tracked_fields],

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -894,11 +894,20 @@ class GetPrevRecordAndNextRecordTestCase(TestCase):
 
 
 class CreateHistoryModelTests(unittest.TestCase):
+    @staticmethod
+    def create_history_model(model, inherited):
+        custom_model_name_prefix = "MockHistorical"
+        records = HistoricalRecords(
+            # Provide a custom history model name, to prevent name collisions
+            # with existing historical models
+            custom_model_name=lambda name: f"{custom_model_name_prefix}{name}",
+        )
+        records.module = model.__module__
+        return records.create_history_model(model, inherited)
+
     def test_create_history_model_with_one_to_one_field_to_integer_field(self):
-        records = HistoricalRecords()
-        records.module = AdminProfile.__module__
         try:
-            records.create_history_model(AdminProfile, False)
+            self.create_history_model(AdminProfile, False)
         except Exception:
             self.fail(
                 "SimpleHistory should handle foreign keys to one to one"
@@ -906,10 +915,8 @@ class CreateHistoryModelTests(unittest.TestCase):
             )
 
     def test_create_history_model_with_one_to_one_field_to_char_field(self):
-        records = HistoricalRecords()
-        records.module = Bookcase.__module__
         try:
-            records.create_history_model(Bookcase, False)
+            self.create_history_model(Bookcase, False)
         except Exception:
             self.fail(
                 "SimpleHistory should handle foreign keys to one to one"
@@ -917,10 +924,8 @@ class CreateHistoryModelTests(unittest.TestCase):
             )
 
     def test_create_history_model_with_multiple_one_to_ones(self):
-        records = HistoricalRecords()
-        records.module = MultiOneToOne.__module__
         try:
-            records.create_history_model(MultiOneToOne, False)
+            self.create_history_model(MultiOneToOne, False)
         except Exception:
             self.fail(
                 "SimpleHistory should handle foreign keys to one to one"

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -77,6 +77,7 @@ from ..models import (
     InheritedRestaurant,
     Library,
     ManyToManyModelOther,
+    ModelWithCustomAttrOneToOneField,
     ModelWithExcludedManyToMany,
     ModelWithFkToModelWithHistoryUsingBaseModelDb,
     ModelWithHistoryInDifferentDb,
@@ -93,6 +94,7 @@ from ..models import (
     PollChildBookWithManyToMany,
     PollChildRestaurantWithManyToMany,
     PollInfo,
+    PollWithAlternativeManager,
     PollWithExcludedFieldsWithDefaults,
     PollWithExcludedFKField,
     PollWithExcludeFields,
@@ -904,6 +906,51 @@ class CreateHistoryModelTests(unittest.TestCase):
         )
         records.module = model.__module__
         return records.create_history_model(model, inherited)
+
+    def test_create_history_model_has_expected_tracked_files_attr(self):
+        def assert_tracked_fields_equal(model, expected_field_names):
+            from .. import models
+
+            history_model = getattr(
+                models, f"Historical{model.__name__}"
+            )
+            self.assertListEqual(
+                [field.name for field in history_model.tracked_fields],
+                expected_field_names,
+            )
+
+        assert_tracked_fields_equal(
+            Poll,
+            ["id", "question", "pub_date"],
+        )
+        assert_tracked_fields_equal(
+            PollWithNonEditableField,
+            ["id", "question", "pub_date", "modified"],
+        )
+        assert_tracked_fields_equal(
+            PollWithExcludeFields,
+            ["id", "question", "place"],
+        )
+        assert_tracked_fields_equal(
+            PollWithExcludedFieldsWithDefaults,
+            ["id", "question"],
+        )
+        assert_tracked_fields_equal(
+            PollWithExcludedFKField,
+            ["id", "question", "pub_date"],
+        )
+        assert_tracked_fields_equal(
+            PollWithAlternativeManager,
+            ["id", "question", "pub_date"],
+        )
+        assert_tracked_fields_equal(
+            PollWithHistoricalIPAddress,
+            ["id", "question", "pub_date"],
+        )
+        assert_tracked_fields_equal(
+            ModelWithCustomAttrOneToOneField,
+            ["id", "poll"],
+        )
 
     def test_create_history_model_with_one_to_one_field_to_integer_field(self):
         try:


### PR DESCRIPTION
## Description
When running the `clean_duplicate_history` command on models with [`excluded_fields` on the model level](https://django-simple-history.readthedocs.io/en/3.1.1/historical_model.html#excluded-fields), a `KeyError` would be raised, as [`HistoricalChanges.diff_against()` would try to read those excluded fields](https://github.com/jazzband/django-simple-history/blob/529dbe2a222f2ed08e680880d3886e461fab283b/simple_history/models.py#L784). This has now been fixed. 

The bugfix was facilitated by also adding a `tracked_fields` attribute to historical models (eff57960e7ad3ce5a2719f6df7fa62661796a783), which can be useful for other (future) purposes as well.

Also did a small refactor of `CreateHistoryModelTests` (669298549b945a27b6d231232ea885272bd7bf10), and added `HistoricalRecords.DEFAULT_MODEL_NAME_PREFIX` (869ae7709169156a738850ce147fb9c5b5f866ea).

## Related Issue
Resolves #988.

## Motivation and Context
See #988.

## How Has This Been Tested?
By running (an unaltered) [`runtests.py`](https://github.com/jazzband/django-simple-history/blob/529dbe2a222f2ed08e680880d3886e461fab283b/runtests.py) locally using Python 3.10.4 and Django 4.1.1, and through [GitHub actions](https://github.com/jazzband/django-simple-history/actions/runs/3320380721).

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.