### PR TITLE
M2M support for inheritance and signals

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -80,6 +80,7 @@ Authors
 - Klaas van Schelven
 - Kris Neuharth
 - Kyle Seever (`kseever <https://github.com/kseever>`_)
+- Léni Gauffier (`legau <https://github.com/legau>`_)
 - Leticia Portella
 - Lucas Wiman
 - Maciej "RooTer" Urbański

--- a/docs/historical_model.rst
+++ b/docs/historical_model.rst
@@ -461,10 +461,14 @@ If you want to track many to many relationships, you need to define them explici
     class Poll(models.Model):
         question = models.CharField(max_length=200)
         categories = models.ManyToManyField(Category)
-        history = HistoricalRecords(many_to_many=[categories])
+        history = HistoricalRecords(m2m_fields=[categories])
 
 This will create a historical intermediate model that tracks each relational change
 between `Poll` and `Category`.
+
+You may also define these fields in a model attribute (by default on `_history_m2m_fields`).
+This is mainly used for inherited models. You can override the attribute name by setting
+your own `m2m_fields_model_field_name` argument on the `HistoricalRecord` instance.
 
 You will see the many to many changes when diffing between two historical records:
 

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -22,6 +22,24 @@ saving a historical record. Arguments passed to the signals include the followin
     using
         The database alias being used
 
+For Many To Many signals you've got the following :
+
+.. glossary::
+    instance
+        The source model instance being saved
+
+    history_instance
+        The corresponding history record
+
+    rows (for pre_create)
+        The elements to be bulk inserted into the m2m table
+
+    created_rows (for post_create)
+        The created elements into the m2m table
+
+    field
+        The recorded field object
+
 To connect the signals to your callbacks, you can use the ``@receiver`` decorator:
 
 .. code-block:: python
@@ -30,6 +48,8 @@ To connect the signals to your callbacks, you can use the ``@receiver`` decorato
     from simple_history.signals import (
         pre_create_historical_record,
         post_create_historical_record
+        pre_create_historical_m2m_records,
+        post_create_historical_m2m_records,
     )
 
     @receiver(pre_create_historical_record)
@@ -39,3 +59,11 @@ To connect the signals to your callbacks, you can use the ``@receiver`` decorato
     @receiver(post_create_historical_record)
     def post_create_historical_record_callback(sender, **kwargs):
         print("Sent after saving historical record")
+
+    @receiver(pre_create_historical_m2m_records)
+    def pre_create_historical_m2m_records_callback(sender, **kwargs):
+        print("Sent before saving many to many field on historical record")
+
+    @receiver(post_create_historical_m2m_records)
+    def post_create_historical_m2m_records_callback(sender, **kwargs):
+        print("Sent after saving many to many field on historical record")

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -400,7 +400,7 @@ class HistoricalRecords:
 
     def _get_history_id_field(self):
         if self.history_id_field:
-            history_id_field = self.history_id_field
+            history_id_field = self.history_id_field.clone()
             history_id_field.primary_key = True
             history_id_field.editable = False
         elif getattr(settings, "SIMPLE_HISTORY_HISTORY_ID_USE_UUID", False):

--- a/simple_history/signals.py
+++ b/simple_history/signals.py
@@ -7,3 +7,11 @@ pre_create_historical_record = django.dispatch.Signal()
 # Arguments: "instance",  "history_instance", "history_date",
 #            "history_user", "history_change_reason", "using"
 post_create_historical_record = django.dispatch.Signal()
+
+# Arguments: "sender",  "rows", "history_instance", "instance",
+#             "field"
+pre_create_historical_m2m_records = django.dispatch.Signal()
+
+# Arguments: "sender",  "created_rows", "history_instance",
+#            "instance", "field"
+post_create_historical_m2m_records = django.dispatch.Signal()

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -117,6 +117,27 @@ class PollWithManyToMany(models.Model):
     history = HistoricalRecords(m2m_fields=[places])
 
 
+class HistoricalRecordsWithExtraFieldM2M(HistoricalRecords):
+    def get_extra_fields_m2m(self, model, through_model, fields):
+        extra_fields = super().get_extra_fields_m2m(model, through_model, fields)
+
+        def get_class_name(self):
+            return self.__class__.__name__
+
+        extra_fields["get_class_name"] = get_class_name
+        return extra_fields
+
+
+class PollWithManyToManyWithIPAddress(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    places = models.ManyToManyField("Place")
+
+    history = HistoricalRecordsWithExtraFieldM2M(
+        m2m_fields=[places], m2m_bases=[IPAddressHistoricalModel]
+    )
+
+
 class PollWithSeveralManyToMany(models.Model):
     question = models.CharField(max_length=200)
     pub_date = models.DateTimeField("date published")

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -127,6 +127,32 @@ class PollWithSeveralManyToMany(models.Model):
     history = HistoricalRecords(m2m_fields=[places, restaurants, books])
 
 
+class PollParentWithManyToMany(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    places = models.ManyToManyField("Place")
+
+    history = HistoricalRecords(
+        m2m_fields=[places],
+        inherit=True,
+    )
+
+    class Meta:
+        abstract = True
+
+
+class PollChildBookWithManyToMany(PollParentWithManyToMany):
+    books = models.ManyToManyField("Book", related_name="books_poll_child")
+    _history_m2m_fields = [books]
+
+
+class PollChildRestaurantWithManyToMany(PollParentWithManyToMany):
+    restaurants = models.ManyToManyField(
+        "Restaurant", related_name="restaurants_poll_child"
+    )
+    _history_m2m_fields = [restaurants]
+
+
 class CustomAttrNameForeignKey(models.ForeignKey):
     def __init__(self, *args, **kwargs):
         self.attr_name = kwargs.pop("attr_name", None)

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -117,6 +117,16 @@ class PollWithManyToMany(models.Model):
     history = HistoricalRecords(m2m_fields=[places])
 
 
+class PollWithManyToManyCustomHistoryID(models.Model):
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    places = models.ManyToManyField("Place")
+
+    history = HistoricalRecords(
+        m2m_fields=[places], history_id_field=models.UUIDField(default=uuid.uuid4)
+    )
+
+
 class HistoricalRecordsWithExtraFieldM2M(HistoricalRecords):
     def get_extra_fields_m2m(self, model, through_model, fields):
         extra_fields = super().get_extra_fields_m2m(model, through_model, fields)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -98,6 +98,7 @@ from ..models import (
     PollWithExcludeFields,
     PollWithHistoricalIPAddress,
     PollWithManyToMany,
+    PollWithManyToManyCustomHistoryID,
     PollWithManyToManyWithIPAddress,
     PollWithNonEditableField,
     PollWithSeveralManyToMany,
@@ -1846,6 +1847,14 @@ class ManyToManyWithSignalsTest(TestCase):
 
         self.assertEqual("places", delta.changes[0].field)
         self.assertEqual(2, len(delta.changes[0].new))
+
+
+class ManyToManyCustomIDTest(TestCase):
+    def setUp(self):
+        self.model = PollWithManyToManyCustomHistoryID
+        self.history_model = self.model.history.model
+        self.place = Place.objects.create(name="Home")
+        self.poll = self.model.objects.create(question="what's up?", pub_date=today)
 
 
 class ManyToManyTest(TestCase):

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -2126,6 +2126,17 @@ class ManyToManyTest(TestCase):
         self.assertListEqual(expected_change.new, delta.changes[0].new)
         self.assertListEqual(expected_change.old, delta.changes[0].old)
 
+        delta = add_record.diff_against(create_record, included_fields=["places"])
+        self.assertEqual(delta.changed_fields, ["places"])
+        self.assertEqual(delta.old_record, create_record)
+        self.assertEqual(delta.new_record, add_record)
+        self.assertEqual(expected_change.field, delta.changes[0].field)
+
+        delta = add_record.diff_against(create_record, excluded_fields=["places"])
+        self.assertEqual(delta.changed_fields, [])
+        self.assertEqual(delta.old_record, create_record)
+        self.assertEqual(delta.new_record, add_record)
+
         self.poll.places.clear()
 
         # First and third records are effectively the same.

--- a/simple_history/tests/tests/test_signals.py
+++ b/simple_history/tests/tests/test_signals.py
@@ -3,11 +3,13 @@ from datetime import datetime
 from django.test import TestCase
 
 from simple_history.signals import (
+    post_create_historical_m2m_records,
     post_create_historical_record,
+    pre_create_historical_m2m_records,
     pre_create_historical_record,
 )
 
-from ..models import Poll
+from ..models import Place, Poll, PollWithManyToMany
 
 today = datetime(2021, 1, 1, 10, 0)
 
@@ -18,6 +20,8 @@ class PrePostCreateHistoricalRecordSignalTest(TestCase):
         self.signal_instance = None
         self.signal_history_instance = None
         self.signal_sender = None
+        self.field = None
+        self.rows = None
 
     def test_pre_create_historical_record_signal(self):
         def handler(sender, instance, **kwargs):
@@ -52,3 +56,59 @@ class PrePostCreateHistoricalRecordSignalTest(TestCase):
         self.assertEqual(self.signal_instance, p)
         self.assertIsNotNone(self.signal_history_instance)
         self.assertEqual(self.signal_sender, p.history.first().__class__)
+
+    def test_pre_create_historical_m2m_records_signal(self):
+        def handler(sender, rows, history_instance, instance, field, **kwargs):
+            self.signal_was_called = True
+            self.signal_instance = instance
+            self.signal_history_instance = history_instance
+            self.signal_sender = sender
+            self.rows = rows
+            self.field = field
+
+        pre_create_historical_m2m_records.connect(handler)
+
+        p = PollWithManyToMany(
+            question="what's up?",
+            pub_date=today,
+        )
+        p.save()
+        self.setUp()
+        p.places.add(
+            Place.objects.create(name="London"), Place.objects.create(name="Paris")
+        )
+
+        self.assertTrue(self.signal_was_called)
+        self.assertEqual(self.signal_instance, p)
+        self.assertIsNotNone(self.signal_history_instance)
+        self.assertEqual(self.signal_sender, p.history.first().places.model)
+        self.assertEqual(self.field, PollWithManyToMany._meta.many_to_many[0])
+        self.assertEqual(len(self.rows), 2)
+
+    def test_post_create_historical_m2m_records_signal(self):
+        def handler(sender, created_rows, history_instance, instance, field, **kwargs):
+            self.signal_was_called = True
+            self.signal_instance = instance
+            self.signal_history_instance = history_instance
+            self.signal_sender = sender
+            self.rows = created_rows
+            self.field = field
+
+        post_create_historical_m2m_records.connect(handler)
+
+        p = PollWithManyToMany(
+            question="what's up?",
+            pub_date=today,
+        )
+        p.save()
+        self.setUp()
+        p.places.add(
+            Place.objects.create(name="London"), Place.objects.create(name="Paris")
+        )
+
+        self.assertTrue(self.signal_was_called)
+        self.assertEqual(self.signal_instance, p)
+        self.assertIsNotNone(self.signal_history_instance)
+        self.assertEqual(self.signal_sender, p.history.first().places.model)
+        self.assertEqual(self.field, PollWithManyToMany._meta.many_to_many[0])
+        self.assertEqual(len(self.rows), 2)


### PR DESCRIPTION
Some M2M enhancements that were not yet merge into #932
## Description
This makes it possible to use the new m2m fields feature with model inheritance.
It also introduces some pre and post m2m save signals.

## Motivation and Context
Abstract models could not be used with previous implementation of historical m2m fields.

## How Has This Been Tested?
Added relevant tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
