### PR TITLE
Documented auto_now usage with bulk_update_with_history

### DIFF
--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -303,5 +303,8 @@ As a convention, you can define a custom manager to update these timestamps auto
         pass
 
     class Poll(models.Model):
+        created_at = models.DateTimeField(auto_now_add=True)
+        updated_at = models.DateTimeField(auto_now=True)
+
         # This must be the first Manager declared in this class, otherwise it won't be detected as the `default_manager`
         objects = UpdatedAtFriendlyManager()

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -275,3 +275,33 @@ arguments using ``excluded_field_kwargs`` as follows:
         history = HistoricalRecords(
             excluded_field_kwargs={"organizer": set(["custom_argument"])}
         )
+
+
+Updated auto_now inside a bulk_update_with_history
+--------------------------------------------------
+
+If you are tracking update timestamps (e.g. ``updated_at``, ``modified_at``), these are only tracked when
+``Model.save()`` is called. As a result, ``bulk_update_with_history`` won't update them.
+
+As a convention, you can define a custom manager to update these timestamps automatically:
+
+.. code-block:: python
+
+    from django.utils import timezone
+
+    class UpdatedAtFriendlyQuerySet(models.QuerySet):
+        def bulk_update(self, objs, fields, *args, **kwargs):
+            timestamp = timezone.now()
+            for obj in objs:
+                assert hasattr(obj, "updated_at"), "Expected bulk_update object to have `updated_at`"
+                obj.updated_at = timestamp
+            assert "updated_at" not in fields, "Encountered unexpected scenario where we set `updated_at` via `bulk_update`"
+            new_fields = tuple(fields) + ("updated_at",)
+            super().bulk_update(objs, new_fields, *args, **kwargs)
+
+    class UpdatedAtFriendlyManager(models.manager.BaseManager.from_queryset(UpdatedAtFriendlyQuerySet)):
+        pass
+
+    class Poll(models.Model):
+        # This must be the first Manager declared in this class, otherwise it won't be detected as the `default_manager`
+        objects = UpdatedAtFriendlyManager()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When using `bulk_update_with_history`, a `DateTimeField` using `auto_now` doesn't automatically update like it does with `Model.save()`

This PR documents the issue under "Common Issues" and offers a convention-based solution

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/jazzband/django-simple-history/issues/1054

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The motivation is to spread awareness of the issue and guide people towards a solution. It seems like a rather quiet bug that can really hurt data accuracy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The code is excerpts from our code

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
