### PR TITLE
Base manager can now be used for clean_duplicate_history

### DIFF
--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -31,6 +31,14 @@ from the duplicate check
 
     $ python manage.py clean_duplicate_history --auto --excluded_fields field1 field2
 
+You can use Django's base manager to perform the cleanup over all records,
+including those that would otherwise be filtered or modified by a
+custom manager, by using the ``--base-manager`` flag.
+
+.. code-block:: bash
+
+    $ python manage.py clean_duplicate_history --auto --base-manager
+
 clean_old_history
 -----------------------
 

--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -1,8 +1,7 @@
 from django.db import transaction
 from django.utils import timezone
 
-from ... import models, utils
-from ...exceptions import NotHistoricalModelError
+from ... import utils
 from . import populate_history
 
 
@@ -36,10 +35,19 @@ class Command(populate_history.Command):
             nargs="+",
             help="List of fields to be excluded from the diff_against check",
         )
+        parser.add_argument(
+            "--base-manager",
+            action="store_true",
+            default=False,
+            help="Use Django's base manager to handle all records stored in the database,"
+            " including those that would otherwise be filtered or modified by a"
+            " custom manager.",
+        )
 
     def handle(self, *args, **options):
         self.verbosity = options["verbosity"]
         self.excluded_fields = options.get("excluded_fields")
+        self.base_manager = options.get("base_manager")
 
         to_process = set()
         model_strings = options.get("models", []) or args
@@ -72,7 +80,10 @@ class Command(populate_history.Command):
                 continue
 
             # Break apart the query so we can add additional filtering
-            model_query = model.objects.all()
+            if self.base_manager:
+                model_query = model._base_manager.all()
+            else:
+                model_query = model._default_manager.all()
 
             # If we're provided a stop date take the initial hit of getting the
             # filtered records to iterate over

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -92,6 +92,22 @@ class PollWithAlternativeManager(models.Model):
     history = HistoricalRecords()
 
 
+class CustomPollManager(models.Manager):
+    def get_queryset(self):
+        return super(CustomPollManager, self).get_queryset().exclude(hidden=True)
+
+
+class PollWithCustomManager(models.Model):
+    some_objects = CustomPollManager()
+    all_objects = models.Manager()
+
+    question = models.CharField(max_length=200)
+    pub_date = models.DateTimeField("date published")
+    hidden = models.BooleanField(default=False)
+
+    history = HistoricalRecords()
+
+
 class IPAddressHistoricalModel(models.Model):
     ip_address = models.GenericIPAddressField()
 


### PR DESCRIPTION
## Description
clean_duplicate_history uses `objects` as manager. This has now been changed to `_default_manager` and an option added to use `_base_mananger`.

Recreated pull request #804 

## Related Issue
none

## Motivation and Context
We use a manager to filter records by default, however we want to remove all records from duplicates.

## How Has This Been Tested?
The command was first run without parameters and then with the new `--base-manager` parameter. Also added a new test.

## Screenshots (if appropriate):
none

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
