### PR TITLE
Add a history_repr field that stores the value of __str__()

### DIFF
--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from simple_history.utils import (
     get_app_model_primary_key_name,
     get_change_reason_from_object,
+    get_historical_repr,
 )
 
 # when converting a historical record to an instance, this attribute is added
@@ -255,6 +256,7 @@ class HistoryManager(models.Manager):
                     instance, "_history_date", default_date or timezone.now()
                 ),
                 history_user=history_user,
+                history_repr=get_historical_repr(instance),
                 history_change_reason=get_change_reason_from_object(instance)
                 or default_change_reason,
                 history_type=history_type,

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -38,7 +38,7 @@ from .signals import (
     pre_create_historical_m2m_records,
     pre_create_historical_record,
 )
-from .utils import get_change_reason_from_object
+from .utils import get_change_reason_from_object, get_historical_repr
 
 try:
     from asgiref.local import Local as LocalContext
@@ -546,6 +546,7 @@ class HistoricalRecords:
         extra_fields = {
             "history_id": self._get_history_id_field(),
             "history_date": models.DateTimeField(db_index=self._date_indexing is True),
+            "history_repr": models.CharField(max_length=128, blank=True),
             "history_change_reason": self._get_history_change_reason_field(),
             "history_type": models.CharField(
                 max_length=1,
@@ -704,6 +705,7 @@ class HistoricalRecords:
         history_change_reason = self.get_change_reason_for_object(
             instance, history_type, using
         )
+        history_repr = get_historical_repr(instance)
         manager = getattr(instance, self.manager_name)
 
         attrs = {}
@@ -717,6 +719,7 @@ class HistoricalRecords:
         history_instance = manager.model(
             history_date=history_date,
             history_type=history_type,
+            history_repr=history_repr,
             history_user=history_user,
             history_change_reason=history_change_reason,
             **attrs,
@@ -729,6 +732,7 @@ class HistoricalRecords:
             history_user=history_user,
             history_change_reason=history_change_reason,
             history_instance=history_instance,
+            history_repr=history_repr,
             using=using,
         )
 
@@ -742,6 +746,7 @@ class HistoricalRecords:
             history_date=history_date,
             history_user=history_user,
             history_change_reason=history_change_reason,
+            history_repr=history_repr,
             using=using,
         )
 

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Case, ForeignKey, ManyToManyField, Q, When
 from django.forms.models import model_to_dict
@@ -196,3 +197,13 @@ def get_change_reason_from_object(obj):
         return getattr(obj, "_change_reason")
 
     return None
+
+
+def get_historical_repr(obj):
+    """
+    Returns the historical representation of an instance (if enabled).
+    Emtpy string "" if not enabled
+    """
+    if getattr(settings, "SIMPLE_HISTORY_HISTORIC_REPR", False):
+        return str(obj)[:128]
+    return ""


### PR DESCRIPTION
Sometimes __str__() requires of a foreign key to represent its value. In those scenarios, two issues appear:

1. Need to perform extra queries. select_related() does not help since the relationship exists in the model, not the historical model.
2. If the related instance is removed, it will fail with DoesNotExist.

One way of overcoming this situation is by storing the value of __str__() at the time we create the Historical Record.

Since this might have a performance penalty, it MUST be explicitly enabled by setting `SIMPLE_HISTORY_HISTORIC_REPR` to True.

## Description
<!--- Describe your changes in detail -->

## Related Issue
#533

## Motivation and Context
Allowing __str__() that use a ForeignKey to work

## How Has This Been Tested?
It hasn't, it's a pretty simple change.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
