### PR TITLE
Fix failing admin tests when testing against Django's main branch

### DIFF
--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -455,6 +455,7 @@ class AdminSiteTest(TestCase):
             admin.history_form_view(request, poll.id, history.pk)
 
         context = {
+            **admin_site.each_context(request),
             # Verify this is set for original object
             "original": poll,
             "change_history": False,
@@ -484,7 +485,10 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        context.update(admin_site.each_context(request))
+        # This key didn't exist prior to Django 4.2
+        if "log_entries" in context:
+            context["log_entries"] = ANY
+
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
         )
@@ -509,6 +513,7 @@ class AdminSiteTest(TestCase):
                 admin.history_form_view(request, poll.id, history.pk)
 
         context = {
+            **admin_site.each_context(request),
             # Verify this is set for history object not poll object
             "original": history.instance,
             "change_history": True,
@@ -538,7 +543,10 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        context.update(admin_site.each_context(request))
+        # This key didn't exist prior to Django 4.2
+        if "log_entries" in context:
+            context["log_entries"] = ANY
+
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
         )
@@ -563,6 +571,7 @@ class AdminSiteTest(TestCase):
                 admin.history_form_view(request, poll.id, history.pk)
 
         context = {
+            **admin_site.each_context(request),
             # Verify this is set for history object not poll object
             "original": poll,
             "change_history": False,
@@ -592,7 +601,10 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        context.update(admin_site.each_context(request))
+        # This key didn't exist prior to Django 4.2
+        if "log_entries" in context:
+            context["log_entries"] = ANY
+
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
         )
@@ -617,6 +629,7 @@ class AdminSiteTest(TestCase):
                 admin.history_form_view(request, obj.id, history.pk)
 
         context = {
+            **admin_site.each_context(request),
             # Verify this is set for history object
             "original": history.instance,
             "change_history": True,
@@ -648,7 +661,10 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        context.update(admin_site.each_context(request))
+        # This key didn't exist prior to Django 4.2
+        if "log_entries" in context:
+            context["log_entries"] = ANY
+
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
         )
@@ -676,6 +692,7 @@ class AdminSiteTest(TestCase):
             )
 
         context = {
+            **admin_site.each_context(request),
             # Verify this is set for original object
             "anything_else": "will be merged into context",
             "original": poll,
@@ -706,7 +723,10 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        context.update(admin_site.each_context(request))
+        # This key didn't exist prior to Django 4.2
+        if "log_entries" in context:
+            context["log_entries"] = ANY
+
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
         )


### PR DESCRIPTION
## Description

[Example of failing tests](https://github.com/jazzband/django-simple-history/actions/runs/4368637153/jobs/7641472149).

The commit https://github.com/django/django/commit/473283d2414fa4bbf1e38d663fe4a58f49bf72b9 added a `log_entries` key to the dict returned by `AdminSite.each_context()`, with a value of type `QuerySet`. The cause of the failing tests seems to be that `QuerySet` hasn't implemented an `__eq__()` method (see [`query.py`](https://github.com/django/django/blob/32d4b61c313be5169137047e9fb3668da20a5d89/django/db/models/query.py#L290)), and since the tests create a new `QuerySet` instance (when calling the `each_context()` method) to compare to the arguments passed to `mock_render`, the instances won't be equal, since they're not the same object.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Through GitHub Actions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
