### PR TITLE
feat(m2m-fields): allow to pass custom through M2M

### DIFF
--- a/simple_history/tests/admin.py
+++ b/simple_history/tests/admin.py
@@ -10,6 +10,7 @@ from .models import (
     Document,
     Employee,
     FileModel,
+    Group,
     Paper,
     Person,
     Planet,
@@ -43,6 +44,7 @@ class PlanetAdmin(SimpleHistoryAdmin):
     history_list_display = ["title", "test_method"]
 
 
+admin.site.register(Group, SimpleHistoryAdmin)
 admin.site.register(Poll, SimpleHistoryAdmin)
 admin.site.register(Choice, ChoiceAdmin)
 admin.site.register(Person, PersonAdmin)

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -145,6 +145,28 @@ class PollWithManyToMany(models.Model):
     history = HistoricalRecords(m2m_fields=[places])
 
 
+class Membership(models.Model):
+    group = models.ForeignKey("Group", on_delete=models.CASCADE)
+    person = models.ForeignKey("Person", on_delete=models.CASCADE)
+    inviter = models.ForeignKey(
+        "Person",
+        on_delete=models.CASCADE,
+        related_name="membership_invites",
+    )
+    invite_reason = models.CharField(max_length=64)
+
+
+class Group(models.Model):
+    name = models.CharField(max_length=128)
+    members = models.ManyToManyField(
+        "Person",
+        through="tests.Membership",
+        through_fields=("group", "person"),
+    )
+
+    history = HistoricalRecords(m2m_fields=[members])
+
+
 class PollWithManyToManyCustomHistoryID(models.Model):
     question = models.CharField(max_length=200)
     pub_date = models.DateTimeField("date published")

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -68,6 +68,7 @@ from ..models import (
     ExternalModelWithAppLabel,
     FileModel,
     ForeignKeyToSelfModel,
+    Group,
     HistoricalChoice,
     HistoricalCustomFKError,
     HistoricalPoll,
@@ -1937,6 +1938,12 @@ class ManyToManyCustomIDTest(TestCase):
         self.history_model = self.model.history.model
         self.place = Place.objects.create(name="Home")
         self.poll = self.model.objects.create(question="what's up?", pub_date=today)
+
+
+class GroupWithManyToManyThroughFieldsTest(TestCase):
+    def setUp(self):
+        self.model = Group
+        self.history_model = self.model.history.model
 
 
 class ManyToManyTest(TestCase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This MR is an attempt for allowing to pass a M2M model (possibly defined with `through`/`through_fields` attributes) to the `m2m_fields`.
The `ManyToManyField` model can be defined with `through` being either a string or a model instance. The `through_fields` can be a tuple of strings.

## Related Issue
Related https://github.com/jazzband/django-simple-history/issues/1094

Related https://github.com/jazzband/django-simple-history/pull/1093

## Motivation and Context
This MR is intended to allow the following to work:

```python
class PollWithManyToManyThroughFields(models.Model):
    question = models.CharField(max_length=200)
    people = models.ManyToManyField("Place", through="Venue", through_fields=("place", "guest"))

    history = HistoricalRecords(m2m_fields=[people])

class Venue(models.Model):
    place = models.ForeignKey("Place", on_delete=models.CASCADE, null=True)
    guest = models.ForeignKey("Person", on_delete=models.CASCADE, null=True)
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
