### PR TITLE
Fix HistoricForeignKey when used together with prefetch_related()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 
+- Fixed ``HistoricForeignKey`` behaviour when used together with ``prefetch_related()``
 
 3.3.0 (2023-03-08)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -860,7 +860,7 @@ class HistoricReverseManyToOneDescriptor(ReverseManyToOneDescriptor):
                         )
                     else:
                         queryset = super().get_queryset()
-                    return self._apply_rel_filters(queryset)
+                    return queryset
 
         return create_reverse_many_to_one_manager(
             HistoricRelationModelManager, self.rel

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -2545,3 +2545,96 @@ class HistoricForeignKeyTest(TestCase):
         )[0]
         pt1i = pt1h.instance
         self.assertEqual(pt1i.organization.name, "original")
+
+    def test_non_historic_to_historic_prefetch(self):
+        org1 = TestOrganizationWithHistory.objects.create(name="org1")
+        org2 = TestOrganizationWithHistory.objects.create(name="org2")
+
+        p1 = TestParticipantToHistoricOrganization.objects.create(
+            name="p1", organization=org1
+        )
+        p2 = TestParticipantToHistoricOrganization.objects.create(
+            name="p2", organization=org1
+        )
+        p3 = TestParticipantToHistoricOrganization.objects.create(
+            name="p3", organization=org2
+        )
+        p4 = TestParticipantToHistoricOrganization.objects.create(
+            name="p4", organization=org2
+        )
+
+        with self.assertNumQueries(2):
+            record1, record2 = TestOrganizationWithHistory.objects.prefetch_related(
+                "participants"
+            ).all()
+
+            self.assertListEqual(
+                [p.name for p in record1.participants.all()],
+                [p1.name, p2.name],
+            )
+            self.assertListEqual(
+                [p.name for p in record2.participants.all()],
+                [p3.name, p4.name],
+            )
+
+    def test_historic_to_non_historic_prefetch(self):
+        org1 = TestOrganization.objects.create(name="org1")
+        org2 = TestOrganization.objects.create(name="org2")
+
+        p1 = TestHistoricParticipantToOrganization.objects.create(
+            name="p1", organization=org1
+        )
+        p2 = TestHistoricParticipantToOrganization.objects.create(
+            name="p2", organization=org1
+        )
+        p3 = TestHistoricParticipantToOrganization.objects.create(
+            name="p3", organization=org2
+        )
+        p4 = TestHistoricParticipantToOrganization.objects.create(
+            name="p4", organization=org2
+        )
+
+        with self.assertNumQueries(2):
+            record1, record2 = TestOrganization.objects.prefetch_related(
+                "participants"
+            ).all()
+
+            self.assertListEqual(
+                [p.name for p in record1.participants.all()],
+                [p1.name, p2.name],
+            )
+            self.assertListEqual(
+                [p.name for p in record2.participants.all()],
+                [p3.name, p4.name],
+            )
+
+    def test_historic_to_historic_prefetch(self):
+        org1 = TestOrganizationWithHistory.objects.create(name="org1")
+        org2 = TestOrganizationWithHistory.objects.create(name="org2")
+
+        p1 = TestHistoricParticipanToHistoricOrganization.objects.create(
+            name="p1", organization=org1
+        )
+        p2 = TestHistoricParticipanToHistoricOrganization.objects.create(
+            name="p2", organization=org1
+        )
+        p3 = TestHistoricParticipanToHistoricOrganization.objects.create(
+            name="p3", organization=org2
+        )
+        p4 = TestHistoricParticipanToHistoricOrganization.objects.create(
+            name="p4", organization=org2
+        )
+
+        with self.assertNumQueries(2):
+            record1, record2 = TestOrganizationWithHistory.objects.prefetch_related(
+                "historic_participants"
+            ).all()
+
+            self.assertListEqual(
+                [p.name for p in record1.historic_participants.all()],
+                [p1.name, p2.name],
+            )
+            self.assertListEqual(
+                [p.name for p in record2.historic_participants.all()],
+                [p3.name, p4.name],
+            )


### PR DESCRIPTION
## Description
This fixes behaviour of `HistoricForeignKey` when used together with `prefetch_related()`.

The following is sufficient to reproduce the bug:
- models:
```python
from django.db import models
from simple_history.models import HistoricalRecords, HistoricForeignKey


class Poll(models.Model):
    question = models.CharField(max_length=200)

    history = HistoricalRecords()


class Choice(models.Model):
    poll = HistoricForeignKey(Poll, on_delete=models.CASCADE)
    choice = models.CharField(max_length=200)
    votes = models.IntegerField()

    history = HistoricalRecords()
```
- code:
```python
from poll.models import Poll, Choice

why_poll = Poll.objects.create(question="why?")
how_poll = Poll.objects.create(question="how?")

Choice.objects.create(poll=why_poll, votes=0)
Choice.objects.create(poll=how_poll, votes=0)

for poll in Poll.objects.prefetch_related("choice_set").all():
    print(poll.choice_set.all())

# expected result:
# <QuerySet [<Choice: Choice object (1)>]>
# <QuerySet [<Choice: Choice object (2)>]>

# actual result:
# <QuerySet [<Choice: Choice object (1)>]>
# <QuerySet []>
```

## Related Issue
#1152 

## Motivation and Context
Property `related_manager_cls` is defined in [`HistoricReverseManyToOneDescriptor`](../blob/3.3.0/simple_history/models.py#L827). This property returns a function call of [`create_reverse_many_to_one_manager`](https://github.com/django/django/blob/4.2/django/db/models/fields/related_descriptors.py#L632) function and passes it `HistoricRelationModelManager` as an argument. However, `create_reverse_many_to_one_manager` defines `RelatedManager`, which subclasses the manager passed as an argument and returns this `RelatedManager` class.

When `prefetch_related` is used, [`get_prefetch_queryset`](https://github.com/django/django/blob/4.2/django/db/models/fields/related_descriptors.py#L730) method of `RelatedManager` is called.
The problem lies in the fact that it bypasses `RelatedManager.get_queryset` method which does filtering to instance (`_apply_rel_filters`) by calling `super().get_queryset()`. But due to inheritance, it gets evaluated to `HistoricRelationModelManager.get_queryset` which does the same filtering as well.

This SQL is generated then (notice the `"poll_choice"."poll_id" = 1` condition):
```sql
SELECT "poll_poll"."id", "poll_poll"."question" FROM "poll_poll"
SELECT "poll_choice"."id", "poll_choice"."poll_id", "poll_choice"."choice", "poll_choice"."votes" FROM "poll_choice" WHERE ("poll_choice"."poll_id" = 1 AND "poll_choice"."poll_id" IN (1, 2))
```

Removing `_apply_rel_filters` call from `HistoricRelationModelManager.get_queryset` solves this problem.

On the other hand, since `create_reverse_many_to_one_manager` returns `RelatedManager`, rather than `HistoricRelationModelManager`, the only way to access `HistoricRelationModelManager.get_queryset` is by calling `super().get_queryset()` from `RelatedManager`. This call can be found:
- in `RelatedManager.get_prefetch_queryset` where it is undesired,
- in `RelatedManager.get_queryset` where `_apply_rel_filters` is called right after `super().get_queryset()`.

Therefore, I believe it is safe to remove it.

## How Has This Been Tested?
Added new tests.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
