### PR TITLE
Add ` bypass_get_user_authorization` flag to allow request object to optionally be passed when working with Anonymous Users

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -98,6 +98,7 @@ Authors
 - Micah Denbraver
 - Michael England
 - Miguel Vargas
+- Mike O'Donnell
 - Mike Spainhower
 - Nathan Villagaray-Carski (`ncvc <https://github.com/ncvc>`_)
 - Nianpeng Li

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Unreleased
 - Added feature to evaluate ``history`` model permissions explicitly when
   ``SIMPLE_HISTORY_ENFORCE_HISTORY_MODEL_PERMISSIONS`` is set to ``True``
   in ``settings`` (gh-1017).
+- Added ``bypass_get_user_authorization`` option to ``HistoricalRecords`` model (gh-1164)
+
 
 3.3.0 (2023-03-08)
 ------------------
@@ -19,7 +21,6 @@ Unreleased
 - Added Arabic translations (gh-1056)
 - Fixed a code example under "Tracking many to many relationships" (gh-1069)
 - Added a ``--base-manager`` option to the ``clean_duplicate_history`` management command (gh-1115)
-- Added ``bypass_get_user_authorization`` option to ``HistoricalRecords`` model (gh-1164)
 
 3.2.0 (2022-09-28)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Unreleased
 - Added Arabic translations (gh-1056)
 - Fixed a code example under "Tracking many to many relationships" (gh-1069)
 - Added a ``--base-manager`` option to the ``clean_duplicate_history`` management command (gh-1115)
+- Added ``bypass_get_user_authorization`` option to ``HistoricalRecords`` model (gh-1164)
 
 3.2.0 (2022-09-28)
 ------------------

--- a/docs/user_tracking.rst
+++ b/docs/user_tracking.rst
@@ -63,6 +63,8 @@ identified with the following key word arguments:
 
 * ``instance``:  The current instance being modified
 * ``request``:  If using the middleware the current request object will be provided if they are authenticated.
+                If you require the request object when dealing with an Unauthenticated user. You can pass
+                `bypass_get_user_authorization=True` to the `HistoricalRecords` constructor.
 
 This is very helpful when using ``register``:
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -103,6 +103,7 @@ class HistoricalRecords:
         m2m_fields=(),
         m2m_fields_model_field_name="_history_m2m_fields",
         m2m_bases=(models.Model,),
+        bypass_get_user_authorization=False,
     ):
         self.user_set_verbose_name = verbose_name
         self.user_set_verbose_name_plural = verbose_name_plural
@@ -124,6 +125,7 @@ class HistoricalRecords:
         self.use_base_model_db = use_base_model_db
         self.m2m_fields = m2m_fields
         self.m2m_fields_model_field_name = m2m_fields_model_field_name
+        self.bypass_get_user_authorization = bypass_get_user_authorization
 
         if isinstance(no_db_index, str):
             no_db_index = [no_db_index]
@@ -752,7 +754,10 @@ class HistoricalRecords:
         except AttributeError:
             request = None
             try:
-                if self.context.request.user.is_authenticated:
+                if (
+                    self.bypass_get_user_authorization
+                    or self.context.request.user.is_authenticated
+                ):
                     request = self.context.request
             except AttributeError:
                 pass


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To expand the flexibility of the library - we have a use case where we want access to the request object even when working with Anonymous Users in our request. This is for the very specific use cases where the source of the request is a known safe entity and we are comfortably ignoring the authenticated process specifically when creating a custom `get_user` method.

## Related Issue
Closes #1164 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
It seemed strange that this flexibility was not already implemented. While being security conscious is always preferred - providing the option to disable this check and always pass the request context through to a the `get_user` method allows for a far more flexible approach to how "user" is defined and created.

In my context - this means I can now pull related user info out of my request context and perform a get_or_create when the get_user method is triggered. Additionally, I can do further processing and decide if I want to set the user to the system-level user when applicable. Because the change is so small - this does not impact existing functionality and should remain a safe option to ignore for most use cases.

Prior to this change - I had a small piece of middleware I would run on the one view I needed this functionality for that faked out the User's authenticated status so that django-simple-history thought it had a legitimate user it was working with. This change effectively avoids the need for hacky code that augments the request object.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

I tested this locally within our internal API and found it fixes my issue. I was able to remove the workaround code I originally had in place.

I have not yet written an additional test as I wanted to see if this PR is something we can include before spending time on tests for it.

My application runs on Python 3.11.2 on an M1 Mac running MacOS 13.2.1 

The changes were easy to test because of the small scope of the change - I feel it is very low risk and does not change existing functionality.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
