### PR TITLE
Fix doc typo to make code block instead of block quote

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,7 +75,7 @@ We make use of `black`_ for code formatting.
 
 .. _black: https://black.readthedocs.io/en/stable/installation_and_usage.html
 
-You can install and run it along with other linters through pre-commit:
+You can install and run it along with other linters through pre-commit::
 
     pre-commit install
     pre-commit run


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix small rst typo

## Related Issue

## Motivation and Context
Makes the intended code block rather than one-line block quote

## How Has This Been Tested?
It's rendered correctly in https://github.com/mjsir911/django-simple-history/blob/msirabella/typo_code_block/CONTRIBUTING.rst#code-formatting

## Screenshots (if appropriate):
![image](https://github.com/jazzband/django-simple-history/assets/17185986/a7e39115-c84d-4568-8fae-67e8a64f81c7)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
