### PR TITLE
use new style middleware and catch exceptions to be sure to clear request in context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
 - Dropped support for Django 4.0, which reached end-of-life on 2023-04-01 (gh-1202)
 - Added support for Django 4.2 (gh-1202)
 - Made ``bulk_update_with_history()`` return the number of model rows updated (gh-1206)
+- Fixed ``HistoryRequestMiddleware`` not cleaning up after itself (i.e. deleting
+  ``HistoricalRecords.context.request``) under some circumstances (gh-1188)
 
 3.3.0 (2023-03-08)
 ------------------

--- a/docs/common_issues.rst
+++ b/docs/common_issues.rst
@@ -124,29 +124,6 @@ Tracking Custom Users
     cannot be set directly on a swapped user model because of the user
     foreign key to track the user making changes.
 
-Using django-webtest with Middleware
-------------------------------------
-
-When using django-webtest_ to test your Django project with the
-django-simple-history middleware, you may run into an error similar to the
-following::
-
-    django.db.utils.IntegrityError: (1452, 'Cannot add or update a child row: a foreign key constraint fails (`test_env`.`core_historicaladdress`, CONSTRAINT `core_historicaladdress_history_user_id_0f2bed02_fk_user_user_id` FOREIGN KEY (`history_user_id`) REFERENCES `user_user` (`id`))')
-
-.. _django-webtest: https://github.com/django-webtest/django-webtest
-
-This error occurs because ``django-webtest`` sets
-``DEBUG_PROPAGATE_EXCEPTIONS`` to true preventing the middleware from cleaning
-up the request. To solve this issue, add the following code to any
-``clean_environment`` or ``tearDown`` method that
-you use:
-
-.. code-block:: python
-
-    from simple_history.middleware import HistoricalRecords
-    if hasattr(HistoricalRecords.context, 'request'):
-        del HistoricalRecords.context.request
-
 Using F() expressions
 ---------------------
 ``F()`` expressions, as described here_, do not work on models that have

--- a/simple_history/middleware.py
+++ b/simple_history/middleware.py
@@ -16,8 +16,8 @@ class HistoryRequestMiddleware:
         HistoricalRecords.context.request = request
         try:
             response = self.get_response(request)
-        except Exception:
-            raise
+        except Exception as e:
+            raise e
         finally:
             del HistoricalRecords.context.request
         return response

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -60,12 +60,6 @@ class AdminSiteTest(TestCase):
     def setUp(self):
         self.user = User.objects.create_superuser("user_login", "u@example.com", "pass")
 
-    def tearDown(self):
-        try:
-            del HistoricalRecords.context.request
-        except AttributeError:
-            pass
-
     def login(self, user=None, superuser=None):
         user = user or self.user
         if superuser is not None:

--- a/simple_history/tests/urls.py
+++ b/simple_history/tests/urls.py
@@ -4,6 +4,7 @@ from django.urls import path, re_path
 from simple_history.tests.view import (
     BucketDataRegisterRequestUserCreate,
     BucketDataRegisterRequestUserDetail,
+    MockableView,
     PollBulkCreateView,
     PollBulkCreateWithDefaultUserView,
     PollBulkUpdateView,
@@ -55,4 +56,5 @@ urlpatterns = [
         PollBulkUpdateWithDefaultUserView.as_view(),
         name="poll-bulk-update-with-default-user",
     ),
+    path("mockable/", MockableView.as_view(), name="mockable"),
 ]

--- a/simple_history/tests/view.py
+++ b/simple_history/tests/view.py
@@ -109,3 +109,10 @@ class BucketDataRegisterRequestUserCreate(CreateView):
 class BucketDataRegisterRequestUserDetail(DetailView):
     model = BucketDataRegisterRequestUser
     fields = ["data"]
+
+
+class MockableView(View):
+    """This view exists to easily mock a response."""
+
+    def get(self, request, *args, **kwargs):
+        return HttpResponse(status=200)


### PR DESCRIPTION
## Description
We caught a problem were the request was reused, causing a strange random behaviour:

- a test makes a request, so the context is updated
- an exception happens and process_response is never called, context still contains WRONG request
- the next test creates some versioned model, and the WRONG request is used

## Related Issue
Resolves #1189.

## How Has This Been Tested?
Extensive pytest codebase using django-simple-history
Fixes the problem we were facing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
