### PR TITLE
Assert table name inherit options

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -106,6 +106,7 @@ Authors
 - Phillip Marshall
 - Prakash Venkatraman (`dopatraman <https://github.com/dopatraman>`_)
 - Rajesh Pappula
+- Ravi Singh (`singhravi1 <https://github.com/singhravi1>`_)
 - Ray Logel
 - Raynald de Lahondes
 - Renaud Perrin (`leminaw <https://github.com/leminaw>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Unreleased
   ``SIMPLE_HISTORY_ENFORCE_HISTORY_MODEL_PERMISSIONS`` is set to ``True``
   in ``settings`` (gh-1017).
 - Fixed ``SimpleHistoryAdmin`` not properly integrating with custom user models (gh-1177)
+- Added assertion to inhibit mentioning of ``table_name`` with ``inherit=True`` attribute.
 
 3.3.0 (2023-03-08)
 ------------------

--- a/docs/historical_model.rst
+++ b/docs/historical_model.rst
@@ -366,7 +366,7 @@ that behavior so that any child model inheriting from it will have
 historical tracking as well. Be careful though, in cases where a model
 can be tracked more than once, ``MultipleRegistrationsError`` will be
 raised. Mentioning this attribute with ``table_name`` attribute would
-cause multiple history tables to have same history table name and therefore 
+cause multiple history tables to have same history table name and therefore
 will give an error.
 
 .. code-block:: python

--- a/docs/historical_model.rst
+++ b/docs/historical_model.rst
@@ -365,7 +365,9 @@ passing ``inherit=True`` to either way of registering you can change
 that behavior so that any child model inheriting from it will have
 historical tracking as well. Be careful though, in cases where a model
 can be tracked more than once, ``MultipleRegistrationsError`` will be
-raised.
+raised. Mentioning this attribute with ``table_name`` attribute would
+cause multiple history tables to have same history table name and therefore 
+will give an error.
 
 .. code-block:: python
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -125,6 +125,9 @@ class HistoricalRecords:
         self.m2m_fields = m2m_fields
         self.m2m_fields_model_field_name = m2m_fields_model_field_name
 
+        if self.inherit and self.table_name:
+            raise TypeError("The `table_name` option cannot be used with `inherit`")
+
         if isinstance(no_db_index, str):
             no_db_index = [no_db_index]
         self.no_db_index = no_db_index

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -126,7 +126,9 @@ class HistoricalRecords:
         self.m2m_fields_model_field_name = m2m_fields_model_field_name
 
         if self.inherit and self.table_name:
-            raise TypeError("The `table_name` option cannot be used with `inherit=True`")
+            raise TypeError(
+                "The `table_name` option cannot be used with `inherit=True`"
+            )
 
         if isinstance(no_db_index, str):
             no_db_index = [no_db_index]

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -126,7 +126,7 @@ class HistoricalRecords:
         self.m2m_fields_model_field_name = m2m_fields_model_field_name
 
         if self.inherit and self.table_name:
-            raise TypeError("The `table_name` option cannot be used with `inherit`")
+            raise TypeError("The `table_name` option cannot be used with `inherit=True`")
 
         if isinstance(no_db_index, str):
             no_db_index = [no_db_index]

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -2545,3 +2545,13 @@ class HistoricForeignKeyTest(TestCase):
         )[0]
         pt1i = pt1h.instance
         self.assertEqual(pt1i.organization.name, "original")
+
+
+class ErrorOnUsingTableNameOptionWithInherit(TestCase):
+    def test_inherited_static_table_name_abstract_base(self):
+        with self.assertRaises(TypeError):
+            class NotToBeUsedAbstractBase(models.Model):
+                history = HistoricalRecords(inherit=True, table_name='not_to_be_used_tracked_table')
+
+                class Meta:
+                    abstract = True

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -2550,8 +2550,11 @@ class HistoricForeignKeyTest(TestCase):
 class ErrorOnUsingTableNameOptionWithInherit(TestCase):
     def test_inherited_static_table_name_abstract_base(self):
         with self.assertRaises(TypeError):
+
             class NotToBeUsedAbstractBase(models.Model):
-                history = HistoricalRecords(inherit=True, table_name='not_to_be_used_tracked_table')
+                history = HistoricalRecords(
+                    inherit=True, table_name="not_to_be_used_tracked_table"
+                )
 
                 class Meta:
                     abstract = True


### PR DESCRIPTION

Mentioning `table_name` attribute would be invalid with `inherit=True` as it will cause multiple tables to have same table name and that error does not clearly specify this issue scenario. Therefore added an informed error message.

## Description
Added check if `inherit=True` and `table_name`, both options are passed and raised a `ValueError`.

## Related Issue

## Motivation and Context
Informing clearly about the issue to the user as they may get confused with the `MultipleRegistrationsError` raised.

## How Has This Been Tested?
Added a test `test_inherited_static_table_name_abstract_base` and used `runtest` to check its validity.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
