### PR TITLE
Update utils.py with adding a return of function bulk_update_with_history

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Unreleased
 - Dropped support for Python 3.7, which reached end-of-life on 2023-06-27 (gh-1202)
 - Dropped support for Django 4.0, which reached end-of-life on 2023-04-01 (gh-1202)
 - Added support for Django 4.2 (gh-1202)
+- Made ``bulk_update_with_history()`` return the number of model rows updated (gh-1206)
 
 3.3.0 (2023-03-08)
 ------------------

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -425,9 +425,9 @@ class BulkUpdateWithHistoryTestCase(TestCase):
         self.assertEqual(Poll.objects.count(), 5)
         self.assertEqual(Poll.history.filter(history_type="~").count(), 5)
 
-    @skipUnless(VERSION >= (4, 0), "Requires Django 4.0 or above")
-    def test_bulk_update_history_row_updated(self):
-        row_updated = bulk_update_with_history(
+    @skipUnless(django.VERSION >= (4, 0), "Requires Django 4.0 or above")
+    def test_bulk_update_with_history_returns_rows_updated(self):
+        rows_updated = bulk_update_with_history(
             self.data,
             Poll,
             fields=["question"],

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest import skipUnless
 from unittest.mock import Mock, patch
 
-from django import VERSION
+import django
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.test import TestCase, TransactionTestCase, override_settings
@@ -432,7 +432,7 @@ class BulkUpdateWithHistoryTestCase(TestCase):
             Poll,
             fields=["question"],
         )
-        self.assertEqual(row_updated, 5)
+        self.assertEqual(rows_updated, 5)
 
 
 class BulkUpdateWithHistoryAlternativeManagersTestCase(TestCase):

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -1,12 +1,12 @@
 from datetime import datetime
-from unittest.mock import Mock, patch
 from unittest import skipUnless
+from unittest.mock import Mock, patch
 
+from django import VERSION
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
-from django import VERSION
 
 from simple_history.exceptions import AlternativeManagerError, NotHistoricalModelError
 from simple_history.tests.models import (

--- a/simple_history/tests/tests/test_utils.py
+++ b/simple_history/tests/tests/test_utils.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 from unittest.mock import Mock, patch
+from unittest import skipUnless
 
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
+from django import VERSION
 
 from simple_history.exceptions import AlternativeManagerError, NotHistoricalModelError
 from simple_history.tests.models import (
@@ -422,6 +424,15 @@ class BulkUpdateWithHistoryTestCase(TestCase):
 
         self.assertEqual(Poll.objects.count(), 5)
         self.assertEqual(Poll.history.filter(history_type="~").count(), 5)
+
+    @skipUnless(VERSION >= (4, 0), "Requires Django 4.0 or above")
+    def test_bulk_update_history_row_updated(self):
+        row_updated = bulk_update_with_history(
+            self.data,
+            Poll,
+            fields=["question"],
+        )
+        self.assertEqual(row_updated, 5)
 
 
 class BulkUpdateWithHistoryAlternativeManagersTestCase(TestCase):

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -173,7 +173,7 @@ def bulk_update_with_history(
         record
     :param manager: Optional model manager to use for the model instead of the default
         manager
-    :return: rows_updated
+    :return: The number of model rows updated, not including any history objects
     """
     history_manager = get_history_manager_for_model(model)
     model_manager = manager or model._default_manager

--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -173,6 +173,7 @@ def bulk_update_with_history(
         record
     :param manager: Optional model manager to use for the model instead of the default
         manager
+    :return: rows_updated
     """
     history_manager = get_history_manager_for_model(model)
     model_manager = manager or model._default_manager
@@ -180,7 +181,7 @@ def bulk_update_with_history(
         raise AlternativeManagerError("The given manager does not belong to the model.")
 
     with transaction.atomic(savepoint=False):
-        model_manager.bulk_update(objs, fields, batch_size=batch_size)
+        rows_updated = model_manager.bulk_update(objs, fields, batch_size=batch_size)
         history_manager.bulk_history_create(
             objs,
             batch_size=batch_size,
@@ -189,6 +190,7 @@ def bulk_update_with_history(
             default_change_reason=default_change_reason,
             default_date=default_date,
         )
+    return rows_updated
 
 
 def get_change_reason_from_object(obj):


### PR DESCRIPTION
Django version above 4.0 returns the rows_updated for function bulk_update.

## Description

## Related Issue

## Motivation and Context
keep the same feature with the Django version above 4.0

## How Has This Been Tested?
with the testcase

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
