### PR TITLE
Pagination and filtering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
 - Dropped support for Django 4.0, which reached end-of-life on 2023-04-01 (gh-1202)
 - Added support for Django 4.2 (gh-1202)
 - Made ``bulk_update_with_history()`` return the number of model rows updated (gh-1206)
+- Added pagination and filtering to SimpleHistoryAdmin (gh-1211)
 
 3.3.0 (2023-03-08)
 ------------------

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -36,6 +36,11 @@ An example of admin integration for the ``Poll`` and ``Choice`` models:
 
 Changing a history-tracked model from the admin interface will automatically record the user who made the change (see :doc:`/user_tracking`).
 
+Changing the number of histoical records shown in admin history list view
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the history list view in admin shows the last 50 records. You can change this by adding a `list_per_page` attribute to the admin class.
+
 
 Displaying custom columns in the admin history list view
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,7 +54,24 @@ By default, the history log displays one line per change containing
 
 You can add other columns (for example the object's status to see
 how it evolved) by adding a ``history_list_display`` array of fields to the
-admin class
+admin class.
+
+.. code-block:: python
+
+    from django.contrib import admin
+    from simple_history.admin import SimpleHistoryAdmin
+    from .models import Poll, Choice
+
+    class PollHistoryAdmin(SimpleHistoryAdmin):
+        history_list_display = ["status"]
+        list_display = ["id", "name", "status"]
+        search_fields  = ['name', 'user__username']
+        list_per_page = 100
+
+    admin.site.register(Poll, PollHistoryAdmin)
+    admin.site.register(Choice, SimpleHistoryAdmin)
+
+..
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This will add pagination and filtering to the simple history admin view. This is needed because it will allow more performance views on instances with many historical records. Currently it is very likely to timeout depending on the settings .

## Related Issue
[1219](https://github.com/jazzband/django-simple-history/issues/1219)

## Motivation and Context
This is needed because it will allow more performance views on instances with many historical records. Currently it is very likely to timeout depending on the settings .

## How Has This Been Tested?
We are currently using this in production and would like to have this natively live in this package. 

## Screenshots (if appropriate):
![image](https://github.com/jazzband/django-simple-history/assets/91849531/5b54d91d-5cb7-485f-a743-390179fe03e3)

## Types of changes
- [x ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] I have run the `pre-commit run` command to format and lint.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [x ] I have added my name and/or github handle to `AUTHORS.rst`
- [x ] I have added my change to `CHANGES.rst`
- [ x] All new and existing tests passed.
