### PR TITLE
feat: m2m_fields accepts field names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changes
 Unreleased
 ----------
 
+- Allow ``HistoricalRecords.m2m_fields`` as str
 
 3.4.0 (2023-08-18)
 ------------------

--- a/docs/historical_model.rst
+++ b/docs/historical_model.rst
@@ -469,9 +469,12 @@ If you want to track many to many relationships, you need to define them explici
 This will create a historical intermediate model that tracks each relational change
 between `Poll` and `Category`.
 
-You may also define these fields in a model attribute (by default on `_history_m2m_fields`).
-This is mainly used for inherited models. You can override the attribute name by setting
-your own `m2m_fields_model_field_name` argument on the `HistoricalRecord` instance.
+You may use either the name of the field or the field instance itself.
+
+You may also define these fields in a class attribute (by default on `_history_m2m_fields`).
+This is mainly used by inherited models not declaring their own `HistoricalRecord`.
+You can override the attribute name by setting your own `m2m_fields_model_field_name`
+argument on the `HistoricalRecord` instance.
 
 You will see the many to many changes when diffing between two historical records:
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -768,7 +768,10 @@ class HistoricalRecords:
             m2m_fields.update(getattr(model, self.m2m_fields_model_field_name))
         except AttributeError:
             pass
-        return [getattr(model, field.name).field for field in m2m_fields]
+        field_names = [
+            field if isinstance(field, str) else field.name for field in m2m_fields
+        ]
+        return [getattr(model, field_name).field for field_name in field_names]
 
 
 def transform_field(field):

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -190,7 +190,7 @@ class PollParentWithManyToMany(models.Model):
 
 class PollChildBookWithManyToMany(PollParentWithManyToMany):
     books = models.ManyToManyField("Book", related_name="books_poll_child")
-    _history_m2m_fields = [books]
+    _history_m2m_fields = ["books"]
 
 
 class PollChildRestaurantWithManyToMany(PollParentWithManyToMany):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
`HistoricalRecords.m2m_fields` should allow names of fields

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1242 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When working with inherited models we can't access the parent m2m field instance in the class definition 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changing one m2m_field into a string

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
