### PR TITLE
Handle missing request

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -64,6 +64,7 @@ Authors
 - Jake Howard (`RealOrangeOne <https://github.com/realorangeone>`_)
 - James Muranga (`jamesmura <https://github.com/jamesmura>`_)
 - James Pulec
+- Jeppe Fihl-Pearson (`Tenzer <https://github.com/Tenzer>`_)
 - Jesse Shapiro
 - Jihoon Baek (`jihoon796 <https://github.com/jihoon796>`_)
 - Jim Gomez

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - Allow ``HistoricalRecords.m2m_fields`` as str
+- Handle if ``request`` is missing in middleware
 
 3.4.0 (2023-08-18)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changes
 Unreleased
 ----------
 
-- Allow ``HistoricalRecords.m2m_fields`` as str
-- Handle if ``request`` is missing in middleware
+- Allow ``HistoricalRecords.m2m_fields`` as str (gh-1243)
+- Fixed ``HistoryRequestMiddleware`` deleting non-existent
+  ``HistoricalRecords.context.request`` in very specific circumstances (gh-1256)
 
 3.4.0 (2023-08-18)
 ------------------

--- a/simple_history/middleware.py
+++ b/simple_history/middleware.py
@@ -13,7 +13,10 @@ def _context_manager(request):
     try:
         yield None
     finally:
-        del HistoricalRecords.context.request
+        try:
+            del HistoricalRecords.context.request
+        except AttributeError:
+            pass
 
 
 @sync_and_async_middleware


### PR DESCRIPTION
## Description
The change in https://github.com/jazzband/django-simple-history/pull/1188 removed a check for if the request context had a "request" entry in it before trying to delete the request data.

## Motivation and Context
This has a side effect of breaking tests in order projects in very specific circumstances, where multiple requests pass through the middleware, concurrently, inside the same thread, as it means the middleware then may try to remove the request key on a context where it already has been removed.

In our case we make us of [before_after](https://github.com/c-oreills/before_after) to test some behaviours that are specific to concurrent requests, which allows us to execute concurrent requests inside one test. In those cases the test have started failing with django-simple-history 3.4.0 because an `AttributeError` is raised when the second request passes back up through the middleware, and tries to delete the request data after it already has been done as part of the first request.

This shouldn't have any impact in real-life scenarios.

## How Has This Been Tested?
I have run our test suite (for proprietary code) before and after this change to verify it no longer raises the `AttributeError` and our test suite passes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
