### PR TITLE
Add temporary `asgiref` requirement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ Unreleased
   (gh-1248)
 - Passing an empty list as the ``fields`` argument to ``bulk_update_with_history()`` is
   now allowed; history records will still be created (gh-1248)
-
+- Added temporary requirement on ``asgiref>=3.6`` while the minimum required Django
+  version is lower than 4.2 (gh-1261)
 
 3.4.0 (2023-08-18)
 ------------------

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,1 +1,3 @@
 -r ./coverage.txt
+# DEV: Remove this requirement entirely when the minimum required Django version is 4.2
+asgiref>=3.6

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ with open("README.rst") as readme, open("CHANGES.rst") as changes:
             "fallback_version": "0.0.0",
         },
         setup_requires=["setuptools_scm"],
+        # DEV: Remove `asgiref` when the minimum required Django version is 4.2
+        install_requires=["asgiref>=3.6"],
         description="Store model history and view/revert changes from admin site.",
         long_description="\n".join((readme.read(), changes.read())),
         long_description_content_type="text/x-rst",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#1209 added an implicit dependency on `asgiref>=3.6`, as [the imported function `iscoroutinefunction()`](https://github.com/jazzband/django-simple-history/blob/bde32e10d94b78958822a9bc1cf0d3ea74380933/simple_history/middleware.py#L3) was introduced in `asgiref` 3.6.0 (see [`asgiref`'s changelog](https://github.com/django/asgiref/blob/3.7.2/CHANGELOG.txt#L33)), but a lower version is the minimum requirement of Django 4.1 and earlier (see e.g. [Django 4.1.11's `setup.cfg`](https://github.com/django/django/blob/4.1.11/setup.cfg#L42)).

This means that users who happen to install `django-simple-history` together with Django 4.1 or lower, might implicitly also install a lower version of `asgiref` than what's actually required to run our code.

The easiest solution to this seems to be adding a requirement for `asgiref>=3.6`, which can be removed when our minimum required Django version is 4.2 or higher.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #1255.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See the discussion of the issue linked above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Through [GitHub actions](https://github.com/jazzband/django-simple-history/actions/runs/6305905275).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
  - This seems unlikely, however, as I'm assuming that most users of this library simply rely on the same version of `asgiref` as is installed with the Django version they're using

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
