### PR TITLE
Make `skip_history_when_saving` work when creating a new object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changes
 Unreleased
 ----------
 
+- Made ``skip_history_when_saving`` work when creating an object - not just when
+  updating an object (gh-1262)
 
 3.7.0 (2024-05-29)
 ------------------

--- a/docs/querying_history.rst
+++ b/docs/querying_history.rst
@@ -175,12 +175,11 @@ model history.
     <Poll: Poll object as of 2010-10-25 18:04:13.814128>
 
 
-Save Without Creating Historical Records
+Save without creating historical records
 ----------------------------------------
 
 If you want to save model objects without triggering the creation of any historical
-records, you can set a ``skip_history_when_saving`` attribute to ``True``
-on each object before saving - for example like this:
+records, you can do the following:
 
 .. code-block:: python
 
@@ -189,7 +188,7 @@ on each object before saving - for example like this:
     # We recommend deleting the attribute afterward
     del poll.skip_history_when_saving
 
-This also works when creating an object, but only when calling the ``save`` method:
+This also works when creating an object, but only when calling ``save()``:
 
 .. code-block:: python
 
@@ -198,6 +197,9 @@ This also works when creating an object, but only when calling the ``save`` meth
     poll.skip_history_when_saving = True
     poll.save()
     del poll.skip_history_when_saving
+
+.. note::
+    Historical records will always be created when calling the ``create()`` manager method.
 
 Alternatively, call the ``save_without_historical_record()`` method on each object
 instead of ``save()``.

--- a/docs/querying_history.rst
+++ b/docs/querying_history.rst
@@ -189,8 +189,7 @@ on each object before saving - for example like this:
     # We recommend deleting the attribute afterward
     del poll.skip_history_when_saving
 
-This also works when creating an object
-(albeit only when calling the model's standard Python constructor followed by saving):
+This also works when creating an object, but only when calling the ``save`` method:
 
 .. code-block:: python
 
@@ -216,7 +215,7 @@ and it looks like this:
             del self.skip_history_when_saving
         return ret
 
-As a final option, you can disable the creation of historical records for *all* models
+Or disable the creation of historical records for *all* models
 by adding the following line to your settings:
 
 .. code-block:: python

--- a/docs/querying_history.rst
+++ b/docs/querying_history.rst
@@ -175,30 +175,49 @@ model history.
     <Poll: Poll object as of 2010-10-25 18:04:13.814128>
 
 
-Save without a historical record
---------------------------------
+Save Without Creating Historical Records
+----------------------------------------
 
-If you want to save a model without a historical record, you can use the following:
+If you want to save model objects without triggering the creation of any historical
+records, you can set a ``skip_history_when_saving`` attribute to ``True``
+on each object before saving - for example like this:
 
 .. code-block:: python
 
-    class Poll(models.Model):
-        question = models.CharField(max_length=200)
-        history = HistoricalRecords()
+    poll.skip_history_when_saving = True
+    poll.save()
+    # We recommend deleting the attribute afterward
+    del poll.skip_history_when_saving
 
-        def save_without_historical_record(self, *args, **kwargs):
-            self.skip_history_when_saving = True
-            try:
-                ret = self.save(*args, **kwargs)
-            finally:
-                del self.skip_history_when_saving
-            return ret
+This also works when creating an object
+(albeit only when calling the model's standard Python constructor followed by saving):
 
+.. code-block:: python
 
-    poll = Poll(question='something')
-    poll.save_without_historical_record()
+    # Note that `Poll.objects.create()` is not called
+    poll = Poll(question="Why?")
+    poll.skip_history_when_saving = True
+    poll.save()
+    del poll.skip_history_when_saving
 
-Or disable history records for all models by putting following lines in your ``settings.py`` file:
+Alternatively, call the ``save_without_historical_record()`` method on each object
+instead of ``save()``.
+This method is automatically added to a model when registering it for history-tracking
+(i.e. defining a ``HistoricalRecords``  manager field on the model),
+and it looks like this:
+
+.. code-block:: python
+
+    def save_without_historical_record(self, *args, **kwargs):
+        self.skip_history_when_saving = True
+        try:
+            ret = self.save(*args, **kwargs)
+        finally:
+            del self.skip_history_when_saving
+        return ret
+
+As a final option, you can disable the creation of historical records for *all* models
+by adding the following line to your settings:
 
 .. code-block:: python
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -180,9 +180,9 @@ class HistoricalRecords:
     def add_extra_methods(self, cls):
         def save_without_historical_record(self, *args, **kwargs):
             """
-            Save model without saving a historical record
+            Save the model instance without creating a historical record.
 
-            Make sure you know what you're doing before you use this method.
+            *Make sure you know what you're doing before using this method.*
             """
             self.skip_history_when_saving = True
             try:
@@ -651,8 +651,9 @@ class HistoricalRecords:
     def post_save(self, instance, created, using=None, **kwargs):
         if not getattr(settings, "SIMPLE_HISTORY_ENABLED", True):
             return
-        if not created and hasattr(instance, "skip_history_when_saving"):
+        if hasattr(instance, "skip_history_when_saving"):
             return
+
         if not kwargs.get("raw", False):
             self.create_historical_record(instance, created and "+" or "~", using=using)
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -182,7 +182,7 @@ class HistoricalRecords:
             """
             Save the model instance without creating a historical record.
 
-            *Make sure you know what you're doing before using this method.*
+            Make sure you know what you're doing before using this method.
             """
             self.skip_history_when_saving = True
             try:

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -2424,12 +2424,12 @@ class ManyToManyTest(TestCase):
         self.assertEqual(self.poll.history.all()[0].places.count(), 0)
         self.assertEqual(poll_2.history.all()[0].places.count(), 2)
 
-    def test_skip_history(self):
+    def test_skip_history_when_updating_an_object(self):
         skip_poll = PollWithManyToMany.objects.create(
             question="skip history?", pub_date=today
         )
-        self.assertEqual(self.poll.history.all().count(), 1)
-        self.assertEqual(self.poll.history.all()[0].places.count(), 0)
+        self.assertEqual(skip_poll.history.all().count(), 1)
+        self.assertEqual(skip_poll.history.all()[0].places.count(), 0)
 
         skip_poll.skip_history_when_saving = True
 
@@ -2437,8 +2437,8 @@ class ManyToManyTest(TestCase):
         skip_poll.save()
         skip_poll.places.add(self.place)
 
-        self.assertEqual(self.poll.history.all().count(), 1)
-        self.assertEqual(self.poll.history.all()[0].places.count(), 0)
+        self.assertEqual(skip_poll.history.all().count(), 1)
+        self.assertEqual(skip_poll.history.all()[0].places.count(), 0)
 
         del skip_poll.skip_history_when_saving
         place_2 = Place.objects.create(name="Place 2")
@@ -2447,6 +2447,18 @@ class ManyToManyTest(TestCase):
 
         self.assertEqual(skip_poll.history.all().count(), 2)
         self.assertEqual(skip_poll.history.all()[0].places.count(), 2)
+
+    def test_skip_history_when_creating_an_object(self):
+        initial_poll_count = PollWithManyToMany.objects.count()
+
+        skip_poll = PollWithManyToMany(question="skip history?", pub_date=today)
+        skip_poll.skip_history_when_saving = True
+        skip_poll.save()
+        skip_poll.places.add(self.place)
+
+        self.assertEqual(skip_poll.history.count(), 0)
+        self.assertEqual(PollWithManyToMany.objects.count(), initial_poll_count + 1)
+        self.assertEqual(skip_poll.places.count(), 1)
 
     @override_settings(SIMPLE_HISTORY_ENABLED=False)
     def test_saving_with_disabled_history_doesnt_create_records(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`skip_history_when_saving` used to only apply when updating an existing object (due to [the `not created` operand in `post_save()`](https://github.com/jazzband/django-simple-history/commit/3c2319c4f9164fb51152e94a03c27f2d978cae9e#diff-a13c48090526a77430e6819c61ffb009b8ed15ffca1b40f3eef675c8c9b77db9L654)), not when creating a new one. This PR fixes that.

Also improved the docs on saving without creating historical records.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Closes #1141.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Fixing the linked issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See the test added in `test_models.py`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
