### PR TITLE
History view pagination

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -83,6 +83,7 @@ Authors
 - Jordon Wing  (`jordonwii <https://github.com/jordonwii>`_)
 - Josh Fyne
 - Josh Thomas (`joshuadavidthomas <https://github.com/joshuadavidthomas>`_)
+- Jurrian Tromp (`jurrian <https://github.com/jurrian>`_)
 - Keith Hackbarth
 - Kevin Foster
 - Kira (`kiraware <https://github.com/kiraware>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Unreleased
 - Updated all djangoproject.com links to reference the stable version (gh-1420)
 - Dropped support for Python 3.8, which reached end-of-life on 2024-10-07 (gh-1421)
 - Added support for Django 5.1 (gh-1388)
+- Added pagination to ``SimpleHistoryAdmin`` (gh-1277)
 
 3.7.0 (2024-05-29)
 ------------------

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -36,12 +36,6 @@ An example of admin integration for the ``Poll`` and ``Choice`` models:
 
 Changing a history-tracked model from the admin interface will automatically record the user who made the change (see :doc:`/user_tracking`).
 
-Changing the number of historical records shown in the admin history list view
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default, the history list view of ``SimpleHistoryAdmin`` shows the last 100 records.
-You can change this by adding a `history_list_per_page` attribute to the admin class.
-
 
 Displaying custom columns in the admin history list view
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -75,6 +69,27 @@ admin class.
 
 
 .. image:: screens/5_history_list_display.png
+
+
+Changing the page size in the admin history list view
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the history list view of ``SimpleHistoryAdmin`` shows the last 100 records.
+You can change this by adding a `history_list_per_page` attribute to the admin class.
+
+
+.. code-block:: python
+
+    from django.contrib import admin
+    from simple_history.admin import SimpleHistoryAdmin
+    from .models import Poll
+
+
+    class PollHistoryAdmin(SimpleHistoryAdmin):
+        # history_list_per_page defaults to 100
+        history_list_per_page = 200
+
+    admin.site.register(Poll, PollHistoryAdmin)
 
 
 Customizing the History Admin Templates

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -36,6 +36,12 @@ An example of admin integration for the ``Poll`` and ``Choice`` models:
 
 Changing a history-tracked model from the admin interface will automatically record the user who made the change (see :doc:`/user_tracking`).
 
+Changing the number of historical records shown in the admin history list view
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, the history list view of ``SimpleHistoryAdmin`` shows the last 100 records.
+You can change this by adding a `history_list_per_page` attribute to the admin class.
+
 
 Displaying custom columns in the admin history list view
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,7 +55,7 @@ By default, the history log displays one line per change containing
 
 You can add other columns (for example the object's status to see
 how it evolved) by adding a ``history_list_display`` array of fields to the
-admin class
+admin class.
 
 .. code-block:: python
 
@@ -62,6 +68,7 @@ admin class
         list_display = ["id", "name", "status"]
         history_list_display = ["status"]
         search_fields = ['name', 'user__username']
+        history_list_per_page = 100
 
     admin.site.register(Poll, PollHistoryAdmin)
     admin.site.register(Choice, SimpleHistoryAdmin)

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -72,13 +72,13 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             except historical_records.model.DoesNotExist:
                 raise http.Http404
 
+        if not self.has_view_history_or_change_history_permission(request, obj):
+            raise PermissionDenied
+
         # Use the same pagination as in Django admin, with history_list_per_page items
         paginator = Paginator(historical_records, self.history_list_per_page)
         page_obj = paginator.get_page(request.GET.get(PAGE_VAR))
         page_range = paginator.get_elided_page_range(page_obj.number)
-
-        if not self.has_view_history_or_change_history_permission(request, obj):
-            raise PermissionDenied
 
         # Set attribute on each historical record from admin methods
         for history_list_entry in history_list_display:

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -7,8 +7,10 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import unquote
+from django.contrib.admin.views.main import PAGE_VAR
 from django.contrib.auth import get_permission_codename, get_user_model
 from django.core.exceptions import PermissionDenied
+from django.core.paginator import Paginator
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404, render
 from django.urls import re_path, reverse
@@ -31,6 +33,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
     object_history_template = "simple_history/object_history.html"
     object_history_list_template = "simple_history/object_history_list.html"
     object_history_form_template = "simple_history/object_history_form.html"
+    history_list_per_page = 100
 
     def get_urls(self):
         """Returns the additional urls used by the Reversion admin."""
@@ -69,6 +72,11 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
             except historical_records.model.DoesNotExist:
                 raise http.Http404
 
+        # Use the same pagination as in Django admin, with history_list_per_page items
+        paginator = Paginator(historical_records, self.history_list_per_page)
+        page_obj = paginator.get_page(request.GET.get(PAGE_VAR))
+        page_range = paginator.get_elided_page_range(page_obj.number)
+
         if not self.has_view_history_or_change_history_permission(request, obj):
             raise PermissionDenied
 
@@ -76,10 +84,10 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         for history_list_entry in history_list_display:
             value_for_entry = getattr(self, history_list_entry, None)
             if value_for_entry and callable(value_for_entry):
-                for record in historical_records:
+                for record in page_obj.object_list:
                     setattr(record, history_list_entry, value_for_entry(record))
 
-        self.set_history_delta_changes(request, historical_records)
+        self.set_history_delta_changes(request, page_obj)
 
         content_type = self.content_type_model_cls.objects.get_for_model(
             get_user_model()
@@ -92,7 +100,10 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         context = {
             "title": self.history_view_title(request, obj),
             "object_history_list_template": self.object_history_list_template,
-            "historical_records": historical_records,
+            "page_obj": page_obj,
+            "page_range": page_range,
+            "page_var": PAGE_VAR,
+            "pagination_required": paginator.count > self.history_list_per_page,
             "module_name": capfirst(force_str(opts.verbose_name_plural)),
             "object": obj,
             "root_path": getattr(self.admin_site, "root_path", None),

--- a/simple_history/templates/simple_history/object_history.html
+++ b/simple_history/templates/simple_history/object_history.html
@@ -7,7 +7,7 @@
     {% if not revert_disabled %}<p>
       {% blocktrans %}Choose a date from the list below to revert to a previous version of this object.{% endblocktrans %}</p>{% endif %}
     <div class="module">
-      {% if historical_records %}
+      {% if page_obj.object_list %}
         {% include object_history_list_template %}
       {% else %}
         <p>{% trans "This object doesn't have a change history." %}</p>

--- a/simple_history/templates/simple_history/object_history_list.html
+++ b/simple_history/templates/simple_history/object_history_list.html
@@ -18,7 +18,7 @@
     </tr>
   </thead>
   <tbody>
-    {% for record in historical_records %}
+    {% for record in page_obj %}
       <tr>
         <td>
           <a href="{% url opts|admin_urlname:'simple_history' object.pk record.pk %}">
@@ -65,3 +65,18 @@
     {% endfor %}
   </tbody>
 </table>
+
+<p class="paginator" style="border-top: 0">
+  {% if pagination_required %}
+    {% for i in page_range %}
+      {% if i == page_obj.paginator.ELLIPSIS %}
+        {{ page_obj.paginator.ELLIPSIS }}
+      {% elif i == page_obj.number %}
+        <span class="this-page">{{ i }}</span>
+      {% else %}
+        <a href="?{{ page_var }}={{ i }}" {% if i == page_obj.paginator.num_pages %} class="end" {% endif %}>{{ i }}</a>
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+  {{ page_obj.paginator.count }} {% blocktranslate count counter=page_obj.paginator.count %}entry{% plural %}entries{% endblocktranslate %}
+</p>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This will add pagination and filtering to the simple history admin view. This is needed because it will allow more performance views on instances with many historical records. Currently it is very likely to timeout depending on the settings.

It uses the same pagination as the default in Django.

## Related Issue
This PR replaces this stale PR: https://github.com/jazzband/django-simple-history/pull/1220
Most of the text of this PR is copied from the stale one.

Closes https://github.com/jazzband/django-simple-history/issues/1117 and closes https://github.com/jazzband/django-simple-history/issues/1219.

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is needed because it will allow more performance views on instances with many historical records. Currently it is very likely to timeout depending on the settings .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a few extra tests on top of what already existed in the stale PR.

## Screenshots (if appropriate):
![image](https://github.com/jazzband/django-simple-history/assets/177496/fbcbaa3f-50f5-4767-8e0a-bf08db15a28c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
