### PR TITLE
Attempts to fix update_change_reason for nullable JSONField fields (issue #1181)

### DIFF
--- a/simple_history/utils.py
+++ b/simple_history/utils.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from django.db.models import Case, ForeignKey, ManyToManyField, Q, When
+from django.db.models import Case, ForeignKey, ManyToManyField, Q, When, JSONField, Value
 from django.forms.models import model_to_dict
 
 from simple_history.exceptions import AlternativeManagerError, NotHistoricalModelError
@@ -18,6 +18,11 @@ def update_change_reason(instance, reason):
         if field.primary_key is True:
             if value is not None:
                 attrs[field.attname] = value
+        elif isinstance(field, JSONField):
+            if value is None and field.null is True:
+                attrs[f"{field.attname}__isnull"] = True
+            else:
+                attrs[field.attname] = Value(value, JSONField())
         else:
             attrs[field.attname] = value
 


### PR DESCRIPTION
## Description
As reported in issue #1181, the implementation of the utility `update_change_reason()` method does not work for models with a nullable JSONField. This is caused by the slightly more convoluted querying mechanisms that has to be applied for JSONFields, please cf. here: [django dev documentation](https://docs.djangoproject.com/en/dev/topics/db/queries/#querying-jsonfield)

This attempts to fix this by checking 
- if a field is a JSONField
- is nullable
- and then using different query language, depending on the `null` status of the field in question.

The strategy assumes that
- a nullable JSONField with a `value` of `None` is not set at all
- a non-nullable JSONField with a `value` of `None` is actually a "NULL" dictionary

**Note**: I am aware that this is not the only way to handle this. But it is the convention I am using in my project and this fixed the issue for me. It may be worthwhile to implement a policy switch to decide how to interpret `None` in this specific case.

## Related Issue
- This attempts to fix issue #1181

## Motivation and Context
I did run into the same issue as the original reporter of the bug report and was stuck. The fix, while admittedly maybe not yet fully universal, depending on the interpretation of a "nullable" JSONField, did solve the issue for me

## How Has This Been Tested?
Tested using my local installation. No unit test implemented but this can be done, if required

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.

