### PR TITLE
Fix: Error in history view of object with forward slash in primary key

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Unreleased
 - Added temporary requirement on ``asgiref>=3.6`` while the minimum required Django
   version is lower than 4.2 (gh-1261)
 - Small performance optimization of the ``clean-duplicate_history`` command (gh-1015)
+- Fixed error in history view of object with forward slash in primary key (gh-1295)
 
 3.4.0 (2023-08-18)
 ------------------

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -126,6 +126,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         model = getattr(
             self.model, self.model._meta.simple_history_manager_attribute
         ).model
+        object_id = unquote(str(object_id))
         obj = get_object_or_404(
             model, **{original_opts.pk.attname: object_id, "history_id": version_id}
         ).instance

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -7,6 +7,7 @@ from functools import partial
 from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.admin.utils import quote
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist
 from django.db import models
@@ -484,7 +485,7 @@ class HistoricalRecords:
             app_label, model_name = opts.app_label, opts.model_name
             return reverse(
                 f"{admin.site.name}:{app_label}_{model_name}_simple_history",
-                args=[getattr(self, opts.pk.attname), self.history_id],
+                args=[quote(getattr(self, opts.pk.attname)), self.history_id],
             )
 
         def get_instance(self):

--- a/simple_history/templates/simple_history/_object_history_list.html
+++ b/simple_history/templates/simple_history/_object_history_list.html
@@ -19,7 +19,7 @@
   <tbody>
     {% for action in action_list %}
       <tr>
-        <td><a href="{% url opts|admin_urlname:'simple_history' object.pk action.pk %}">{{ action.history_object }}</a></td>
+        <td><a href="{% url opts|admin_urlname:'simple_history' object.pk|admin_urlquote action.pk %}">{{ action.history_object }}</a></td>
         {% for column in history_list_display %}
         <td scope="col">{{ action|getattribute:column }}</th>
         {% endfor %}

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -226,6 +226,14 @@ class AdminSiteTest(TestCase):
         response = self.client.get(get_history_url(book))
         self.assertContains(response, book.history.all()[0].revert_url())
 
+    def test_forward_slash_in_pk(self):
+        self.login()
+        book = Book(isbn="9780147/513731")
+        book._history_user = self.user
+        book.save()
+        response = self.client.get(get_history_url(book))
+        self.assertContains(response, book.history.all()[0].revert_url())
+
     def test_historical_user_no_setter(self):
         """Demonstrate admin error without `_historical_user` setter.
         (Issue #43)
@@ -458,7 +466,7 @@ class AdminSiteTest(TestCase):
             "change_history": False,
             "title": "Revert %s" % force_str(poll),
             "adminform": ANY,
-            "object_id": poll.id,
+            "object_id": str(poll.id),
             "is_popup": False,
             "media": ANY,
             "errors": ANY,
@@ -517,7 +525,7 @@ class AdminSiteTest(TestCase):
             "change_history": True,
             "title": "Revert %s" % force_str(history.instance),
             "adminform": ANY,
-            "object_id": poll.id,
+            "object_id": str(poll.id),
             "is_popup": False,
             "media": ANY,
             "errors": ANY,
@@ -576,7 +584,7 @@ class AdminSiteTest(TestCase):
             "change_history": False,
             "title": "Revert %s" % force_str(poll),
             "adminform": ANY,
-            "object_id": poll.id,
+            "object_id": str(poll.id),
             "is_popup": False,
             "media": ANY,
             "errors": ANY,
@@ -635,7 +643,7 @@ class AdminSiteTest(TestCase):
             "change_history": True,
             "title": "Revert %s" % force_str(history.instance),
             "adminform": ANY,
-            "object_id": obj.id,
+            "object_id": str(obj.id),
             "is_popup": False,
             "media": ANY,
             "errors": ANY,
@@ -700,7 +708,7 @@ class AdminSiteTest(TestCase):
             "change_history": False,
             "title": "Revert %s" % force_str(poll),
             "adminform": ANY,
-            "object_id": poll.id,
+            "object_id": str(poll.id),
             "is_popup": False,
             "media": ANY,
             "errors": ANY,


### PR DESCRIPTION

- Used quote method to convert a primary key value into a string that can be used in a URL for a history view.
- Used unquote method  to convert quoted primary key back into its original form for history form view.

## Description
This error occurs while rendering object URL with primary key in Change History view. This [line](https://github.com/jazzband/django-simple-history/blob/master/simple_history/templates/simple_history/_object_history_list.html#L22) causes the issue.

I was able to fix this issue using [admin_urlquote](https://github.com/django/django/blob/main/django/contrib/admin/templatetags/admin_urls.py#L17) filter on object.pk. However, it breaks[ history form view](https://github.com/jazzband/django-simple-history/blob/master/simple_history/admin.py#L123C9-L123C26) as it receives encoded value in object id and object does not exist with this value. To fix this, I used [unquote](https://github.com/django/django/blob/main/django/contrib/admin/utils.py#L97) method to to convert quoted primary key back into its original form for history form view.

## Related Issue
#1295

## Motivation and Context
See Description

## How Has This Been Tested?

- I wrote unit tests that render a history view for an object with "/" in the primary key.
- After making these changes some tests related to history form view were broken, because these tests was passing integer to history_form_view method and unquote method does not work with integers. I fixed those tests, by converting these ids to string for assertion.
- I manually tested these changes via admin portal.
- These changes affects areas of code that uses history urls.

## Screenshots (if appropriate):

**Error Before this fix**

<img width="1676" alt="Screenshot 2024-01-23 at 10 46 49 PM" src="https://github.com/jazzband/django-simple-history/assets/16428585/4b405d33-3296-4d2e-9add-281b956a2c6a">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
