### PR TITLE
Fix SimpleHistoryAdmin to consistently use AUTH_USER_MODEL in history

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,6 +43,7 @@ Authors
 - Dmytro Shyshov (`xahgmah <https://github.com/xahgmah>`_)
 - Edouard Richard (`vied12 <https://github.com/vied12>` _)
 - Eduardo Cuducos
+- Enric Pou (`epou <https://github.com/epou>`_)
 - Erik van Widenfelt (`erikvw <https://github.com/erikvw>`_)
 - Fábio Capuano (`fabiocapsouza <https://github.com/fabiocapsouza`_)
 - Filipe Pina (@fopina)

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.admin.utils import unquote
-from django.contrib.auth import get_permission_codename, get_user_model
+from django.contrib.auth import get_permission_codename
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, render
 from django.urls import re_path, reverse
@@ -71,7 +71,7 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
                     setattr(list_entry, history_list_entry, value_for_entry(list_entry))
 
         content_type = self.content_type_model_cls.objects.get_for_model(
-            get_user_model()
+            history.model._history_user_model
         )
 
         admin_user_view = "admin:{}_{}_change".format(

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -112,7 +112,7 @@ class HistoricalRecords:
         self.inherit = inherit
         self.history_id_field = history_id_field
         self.history_change_reason_field = history_change_reason_field
-        self.user_model = user_model
+        self.user_model = user_model or get_user_model()
         self.get_user = get_user
         self.cascade_delete_history = cascade_delete_history
         self.custom_model_name = custom_model_name
@@ -276,6 +276,7 @@ class HistoricalRecords:
             "__module__": self.module,
             "_history_excluded_fields": self.excluded_fields,
             "_history_m2m_fields": self.get_m2m_fields_from_model(model),
+            "_history_user_model": self.user_model,
             "tracked_fields": self.fields_included(model),
         }
 
@@ -423,13 +424,9 @@ class HistoricalRecords:
                 "history_user_id": self.user_id_field,
             }
         else:
-            user_model = self.user_model or getattr(
-                settings, "AUTH_USER_MODEL", "auth.User"
-            )
-
             history_user_fields = {
                 "history_user": models.ForeignKey(
-                    user_model,
+                    self.user_model,
                     null=True,
                     related_name=self.user_related_name,
                     on_delete=models.SET_NULL,

--- a/simple_history/tests/admin.py
+++ b/simple_history/tests/admin.py
@@ -5,6 +5,7 @@ from simple_history.tests.external.models import ExternalModelWithCustomUserIdFi
 
 from .models import (
     Book,
+    BucketData,
     Choice,
     ConcreteExternal,
     Document,
@@ -54,3 +55,4 @@ admin.site.register(ConcreteExternal, SimpleHistoryAdmin)
 admin.site.register(ExternalModelWithCustomUserIdField, SimpleHistoryAdmin)
 admin.site.register(FileModel, FileModelAdmin)
 admin.site.register(Planet, PlanetAdmin)
+admin.site.register(BucketData, SimpleHistoryAdmin)

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -598,6 +598,24 @@ class HistoricalRecordsTest(TestCase):
         self.assertEqual(most_recent.question, p.question)
         self.assertEqual(most_recent.place, p.place)
 
+    def test_history_user_model_is_auth_user_as_default(self):
+        self.assertEqual(
+            get_user_model(),
+            get_history_model_for_model(Poll)._history_user_model
+        )
+
+    def test_history_user_model_is_user_model_on_override(self):
+        self.assertEqual(
+            BucketMember,
+            get_history_model_for_model(BucketData)._history_user_model
+        )
+
+    def test_history_user_model_is_user_model_on_override_register(self):
+        self.assertEqual(
+            BucketMember,
+            get_history_model_for_model(BucketDataRegisterChangedBy)._history_user_model
+        )
+
     def test_user_model_override(self):
         user1 = User.objects.create_user("user1", "1@example.com")
         user2 = User.objects.create_user("user2", "1@example.com")
@@ -2292,6 +2310,11 @@ class MultiDBExplicitHistoryUserIDTest(TestCase):
         self.assertEqual(user_id, instance.history.first().history_user_id)
         self.assertIsNone(instance.history.first().history_user)
 
+    def test_history_user_model_is_auth_user(self):
+        self.assertEqual(
+            get_user_model(),
+            get_history_model_for_model(ExternalModelWithCustomUserIdField)._history_user_model
+        )
 
 class RelatedNameTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Adapt the admin user change view depending on the `HistoryRecord.user_model` provided (default: AUTH_USER_MODEL) on the admin history view.
- Added ability to track custom user_model with explicit custom ``history_user_model``

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/jazzband/django-simple-history/issues/1302

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The SimpleHistoryAdmin.history_view assumes that the user model associated with the history_user is the one specified in AUTH_USER_MODEL, disregarding any class provided in the HistoricalRecords.user_model argument.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
