### PR TITLE
Improve support to django model translation fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -106,6 +106,7 @@ Authors
 - Mike Spainhower
 - Muneeb Shahid (`muneeb706 <https://github.com/muneeb706>`_)
 - Nathan Villagaray-Carski (`ncvc <https://github.com/ncvc>`_)
+- Natanael Maia (`natanrmaia <https://github.com/natanrmaia/>`_)
 - Nianpeng Li
 - Nick Träger
 - Noel James (`NoelJames <https://github.com/NoelJames>`_)

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -105,8 +105,8 @@ Authors
 - Miguel Vargas
 - Mike Spainhower
 - Muneeb Shahid (`muneeb706 <https://github.com/muneeb706>`_)
-- Nathan Villagaray-Carski (`ncvc <https://github.com/ncvc>`_)
 - Natanael Maia (`natanrmaia <https://github.com/natanrmaia/>`_)
+- Nathan Villagaray-Carski (`ncvc <https://github.com/ncvc>`_)
 - Nianpeng Li
 - Nick Träger
 - Noel James (`NoelJames <https://github.com/NoelJames>`_)

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -330,6 +330,14 @@ class HistoricalRecords:
         for field in self.fields_included(model):
             field = copy.copy(field)
             field.remote_field = copy.copy(field.remote_field)
+            if field.__class__.__name__ == 'TranslationCharField':
+                old_field = field
+                field.__class__ = models.CharField
+                if hasattr(field, "max_length"):
+                    field.max_length = old_field.max_length if old_field.max_length else 255
+            if field.__class__.__name__ == 'TranslationTextField':
+                old_field = field
+                field.__class__ = models.TextField
             if isinstance(field, OrderWrt):
                 # OrderWrt is a proxy field, switch to a plain IntegerField
                 field.__class__ = models.IntegerField

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -330,12 +330,14 @@ class HistoricalRecords:
         for field in self.fields_included(model):
             field = copy.copy(field)
             field.remote_field = copy.copy(field.remote_field)
-            if field.__class__.__name__ == 'TranslationCharField':
+            if field.__class__.__name__ == "TranslationCharField":
                 old_field = field
                 field.__class__ = models.CharField
                 if hasattr(field, "max_length"):
-                    field.max_length = old_field.max_length if old_field.max_length else 255
-            if field.__class__.__name__ == 'TranslationTextField':
+                    field.max_length = (
+                        old_field.max_length if old_field.max_length else 255
+                    )
+            if field.__class__.__name__ == "TranslationTextField":
                 old_field = field
                 field.__class__ = models.TextField
             if isinstance(field, OrderWrt):


### PR DESCRIPTION
## Description
The proposed change converts the django model translations fields to char or text fields, this way django-simple-history can iterate better and change its properties.

## Related Issue
https://github.com/jazzband/django-simple-history/issues/1299

## Motivation and Context
Django Simple History cannot change django model translation field properties correctly in its current version.

## How Has This Been Tested?
Creating new models with django model translation fields and changing old models.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
