### PR TITLE
Display a running diff in the object history list page

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -39,6 +39,7 @@ Authors
 - David Grochowski (`ThePumpingLemma <https://github.com/ThePumpingLemma>`_)
 - David Hite
 - David Smith
+- David Toulmin (`davidtoulmin <https://github.com/davidtoulmin>`_)
 - `ddabble <https://github.com/ddabble>`_
 - Dmytro Shyshov (`xahgmah <https://github.com/xahgmah>`_)
 - Edouard Richard (`vied12 <https://github.com/vied12>` _)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
   version is lower than 4.2 (gh-1261)
 - Small performance optimization of the ``clean-duplicate_history`` command (gh-1015)
 - Support Simplified Chinese translation (gh-1281)
+- Added a running diff to the _object_history_list.html so users can see a list of all field changes made in each change
 
 3.4.0 (2023-08-18)
 ------------------

--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -70,6 +70,15 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
                 for list_entry in action_list:
                     setattr(list_entry, history_list_entry, value_for_entry(list_entry))
 
+        previous = None
+        for list_entry in reversed(action_list):
+            if previous:
+                value = list_entry.diff_against(previous).changes
+            else:
+                value = ""
+            setattr(list_entry, "diff", value)
+            previous = list_entry
+
         content_type = self.content_type_model_cls.objects.get_for_model(
             get_user_model()
         )

--- a/simple_history/templates/simple_history/_object_history_list.html
+++ b/simple_history/templates/simple_history/_object_history_list.html
@@ -10,6 +10,7 @@
       {% for column in history_list_display %}
         <th scope="col">{% trans column %}</th>
       {% endfor %}
+      <th scope="col">{% trans 'Changes from previous' %}</th>
       <th scope="col">{% trans 'Date/time' %}</th>
       <th scope="col">{% trans 'Comment' %}</th>
       <th scope="col">{% trans 'Changed by' %}</th>
@@ -21,8 +22,9 @@
       <tr>
         <td><a href="{% url opts|admin_urlname:'simple_history' object.pk action.pk %}">{{ action.history_object }}</a></td>
         {% for column in history_list_display %}
-        <td scope="col">{{ action|getattribute:column }}</th>
+        <td scope="col">{{ action|getattribute:column }}</td>
         {% endfor %}
+        <td>{% include "simple_history/diff_table.html" with diff=action.diff %}</td>
         <td>{{ action.history_date }}</td>
         <td>{{ action.get_history_type_display }}</td>
         <td>

--- a/simple_history/templates/simple_history/diff_table.html
+++ b/simple_history/templates/simple_history/diff_table.html
@@ -1,0 +1,21 @@
+{% load i18n %}
+{% if diff %}
+<table>
+    <thead>
+        <th>{% trans 'Field' %}</th>
+        <th>{% trans 'Old Value' %}</th>
+        <th>{% trans 'New Value' %}</th>
+    </thead>
+    <tbody>
+    {% for change in diff %}
+        <tr>
+            <td>{{ change.field }}</td>
+            <td>{{ change.old }}</td>
+            <td>{{ change.new }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% else %}
+{% trans 'No Change' %}
+{% endif %}


### PR DESCRIPTION
## Description
Add a column to the _object_history_list.html template that displays a table of the specific field changes made in each history object in the list (i.e for each item in the _object_history_list display the item.diff_against(previous_item)

## Related Issue
https://github.com/jazzband/django-simple-history/issues/1308

## Motivation and Context
This is a new feature, that I think makes the product much more helpful in tracking the changes in an object. It allows the user to see what changes were made in each history object, and allows browsing of changes, and makes it much easier to track down a specific change in the history. This is a feature the admin team for our website asked me to add, and it seems like a nice piece of functionality to add back to the codebase. I'm very happy to take suggestions on ways I can approve this, and will go through the testing and linting etc if people like the suggestion

## How Has This Been Tested?
I have only tested manually for now, I wanted to get feedback on the idea before I went too far with the changes or testing

## Screenshots (if appropriate):
![image](https://github.com/jazzband/django-simple-history/assets/12080544/941e4d58-d727-43c7-a990-2e5777330fb3)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
