### PR TITLE
fix(diff_against): support diffing against deleted records

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,6 +43,7 @@ Authors
 - Dmytro Shyshov (`xahgmah <https://github.com/xahgmah>`_)
 - Edouard Richard (`vied12 <https://github.com/vied12>` _)
 - Eduardo Cuducos
+- Eric Uriostigue (`euriostigue <https://github.com/euriostigue>`_)
 - Erik van Widenfelt (`erikvw <https://github.com/erikvw>`_)
 - Fábio Capuano (`fabiocapsouza <https://github.com/fabiocapsouza`_)
 - Filipe Pina (@fopina)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changes
 
 Unreleased
 ----------
+- Fixed `diff_against` to work with deleted objects (gh-1312)
 
 - Support custom History ``Manager`` and ``QuerySet`` classes (gh-1280)
 

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -965,8 +965,8 @@ class HistoricalChanges:
         current_values = model_to_dict(self, fields=fields)
 
         for field in fields:
-            old_value = old_values[field]
-            current_value = current_values[field]
+            old_value = None if old_history.history_type == "-" else old_values[field]
+            current_value = None if self.history_type == "-" else current_values[field]
 
             if old_value != current_value:
                 changes.append(ModelChange(field, old_value, current_value))


### PR DESCRIPTION
This modifies `diff_against` to compare against records when `history_type` is `-`.

## Description
When determining the record value for comparison, check if the `history_type` corresponds to a deletion. Use the value `None` if the record corresponds to a deletion record.

## Related Issue
Closes #1307

## Motivation and Context
In our application, we use `diff_against` to identify changes between records. A deletion was not detected as a change by `diff_against`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
An added unit test checks comparisons in both directions:
- comparing a deleted record to a created record
- comparing a creation record to a deleted record

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
