### PR TITLE
Improve performance of latest_of_each for PostgreSQL

### DIFF
--- a/simple_history/manager.py
+++ b/simple_history/manager.py
@@ -77,7 +77,7 @@ class HistoricalQuerySet(QuerySet):
             latest_pk_attr_historic_ids = (
                 self.order_by(self._pk_attr, "-history_date", "-pk")
                 .distinct(self._pk_attr)
-                .values_list("pk", flat=True)
+                .values("pk")
             )
             latest_historics = self.filter(history_id__in=latest_pk_attr_historic_ids)
         else:


### PR DESCRIPTION
When getting historic PKs, do not evaluate the query but let the database decide how to improve this sub-query.
This improves the performance as the roundtrip into Python lists are skipped.


## Motivation and Context
For a huge dataset, this would be a memory and performance issue when calling `values_list` instead of letting the database handle the sub-query directly.

## How Has This Been Tested?
No test changes needed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation. (not needed)
- [x] I have updated the documentation accordingly. (not needed)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes. (no changes)
- [x] I have added my name and/or github handle to `AUTHORS.rst` (I think that's too small of a change... ;))
- [ ] I have added my change to `CHANGES.rst` (idk if this is too small?)
- [x] All new and existing tests passed.
