### PR TITLE
Fix m2m saved when simple history disabled

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -141,6 +141,7 @@ Authors
 - `ddusi <https://github.com/ddusi>`_
 - `DanialErfanian <https://github.com/DanialErfanian>`_
 - `Sridhar Marella <https://github.com/sridhar562345>`_
+- `Mattia Fantoni <https://github.com/MattFanto>`_
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,8 +25,8 @@ Unreleased
 - Added a "Changes" column to ``SimpleHistoryAdmin``'s object history table, listing
   the changes between each historical record of the object; see the docs under
   "Customizing the History Admin Templates" for overriding its template context (gh-1128)
-- Fixed an issue causing m2m historical record to be saved even when
-  SIMPLE_HISTORY_ENABLED = False in settings.py (gh-1328)
+- Fixed the setting ``SIMPLE_HISTORY_ENABLED = False`` not preventing M2M historical
+  records from being created (gh-1328)
 
 3.5.0 (2024-02-19)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Unreleased
 - Added a "Changes" column to ``SimpleHistoryAdmin``'s object history table, listing
   the changes between each historical record of the object; see the docs under
   "Customizing the History Admin Templates" for overriding its template context (gh-1128)
+- Fixed an issue causing m2m historical record to be saved even when
+  SIMPLE_HISTORY_ENABLED = False in settings.py
 
 3.5.0 (2024-02-19)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ Unreleased
   the changes between each historical record of the object; see the docs under
   "Customizing the History Admin Templates" for overriding its template context (gh-1128)
 - Fixed an issue causing m2m historical record to be saved even when
-  SIMPLE_HISTORY_ENABLED = False in settings.py
+  SIMPLE_HISTORY_ENABLED = False in settings.py (gh-1328)
 
 3.5.0 (2024-02-19)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -673,6 +673,8 @@ class HistoricalRecords:
         return utils.get_change_reason_from_object(instance)
 
     def m2m_changed(self, instance, action, attr, pk_set, reverse, **_):
+        if not getattr(settings, "SIMPLE_HISTORY_ENABLED", True):
+            return
         if hasattr(instance, "skip_history_when_saving"):
             return
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -2411,6 +2411,22 @@ class ManyToManyTest(TestCase):
         self.assertEqual(skip_poll.history.all().count(), 2)
         self.assertEqual(skip_poll.history.all()[0].places.count(), 2)
 
+    @override_settings(SIMPLE_HISTORY_ENABLED=False)
+    def test_saving_with_disabled_history_doesnt_create_records(self):
+        # 1 from `setUp()`
+        self.assertEqual(PollWithManyToMany.history.count(), 1)
+
+        poll = PollWithManyToMany.objects.create(
+            question="skip history?", pub_date=today
+        )
+        poll.question = "huh?"
+        poll.save()
+        poll.places.add(self.place)
+
+        self.assertEqual(poll.history.count(), 0)
+        # The count should not have changed
+        self.assertEqual(PollWithManyToMany.history.count(), 1)
+
     def test_diff_against(self):
         self.poll.places.add(self.place)
         add_record, create_record = self.poll.history.all()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing the following bug: m2m relationships ignores the SIMPLE_HISTORY_ENABLED = False, even when disabled the library is still saving the historical record.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #1328

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
