### PR TITLE
Fix O(n) queries when adding M2M objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ Unreleased
   "Customizing the History Admin Templates" for overriding its template context (gh-1128)
 - Fixed the setting ``SIMPLE_HISTORY_ENABLED = False`` not preventing M2M historical
   records from being created (gh-1328)
+- For history-tracked M2M fields, adding M2M objects (using ``add()`` or ``set()``)
+  used to cause a number of database queries that scaled linearly with the number of
+  objects; this has been fixed to now be a constant number of queries (gh-1333)
 
 3.5.0 (2024-02-19)
 ------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

For history-tracked M2M fields, adding M2M objects (using `add()` or `set()`) used to cause a number of database queries that scaled linearly with the number of objects (*O(n)*); this has been fixed to now be a constant number of queries (*O(1)*).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #1317.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

See linked issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See the added test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
