### PR TITLE
Drop support for Django 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13-dev']
-        django-version: ['3.2', '4.2', '5.0', 'main']
+        django-version: ['4.2', '5.0', 'main']
 
         exclude:
           # Exclude py3.8 and py3.9 for Django main and 5.0
@@ -24,14 +24,6 @@ jobs:
             django-version: 'main'
           - python-version: '3.9'
             django-version: 'main'
-
-          # Exclude py3.11, py3.12 and py3.13 for Django 3.2
-          - python-version: '3.11'
-            django-version: '3.2'
-          - python-version: '3.12'
-            django-version: '3.2'
-          - python-version: '3.13-dev'
-            django-version: '3.2'
 
     services:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changes
 Unreleased
 ----------
 
+- Dropped support for Django 3.2, which reached end-of-life on 2024-04-01 (gh-1344)
+- Removed the temporary requirement on ``asgiref>=3.6`` added in 3.5.0,
+  now that the minimum required Django version is 4.2 (gh-1344)
 
 3.6.0 (2024-05-26)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,6 @@ This app supports the following combinations of Django and Python:
 ==========  ========================
   Django      Python
 ==========  ========================
-3.2         3.8, 3.9, 3.10
 4.2         3.8, 3.9, 3.10, 3.11, 3.12, 3.13-dev
 5.0         3.10, 3.11, 3.12, 3.13-dev
 main        3.10, 3.11, 3.12, 3.13-dev

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,6 @@ This app supports the following combinations of Django and Python:
 ==========  =======================
   Django      Python
 ==========  =======================
-3.2         3.8, 3.9, 3.10
 4.2         3.8, 3.9, 3.10, 3.11, 3.12, 3.13-dev
 5.0         3.10, 3.11, 3.12, 3.13-dev
 main        3.10, 3.11, 3.12, 3.13-dev

--- a/requirements/postgres.txt
+++ b/requirements/postgres.txt
@@ -1,4 +1,1 @@
-# DEV: Replace this with `psycopg[binary]` when the minimum required Django version is
-#      4.2 or higher, as this is likely to be deprecated in the future
-#      (see https://docs.djangoproject.com/en/4.2/releases/4.2/#psycopg-3-support)
-psycopg2-binary==2.9.9
+psycopg[binary]==3.1.19

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,3 +1,1 @@
 -r ./coverage.txt
-# DEV: Remove this requirement entirely when the minimum required Django version is 4.2
-asgiref>=3.6

--- a/runtests.py
+++ b/runtests.py
@@ -135,6 +135,12 @@ DEFAULT_SETTINGS = dict(  # nosec
             },
         }
     ],
+    STORAGES={
+        "default": {
+            # Speeds up tests and prevents locally storing files created through them
+            "BACKEND": "django.core.files.storage.InMemoryStorage",
+        },
+    },
     DEFAULT_AUTO_FIELD="django.db.models.AutoField",
     USE_TZ=False,
 )
@@ -145,16 +151,6 @@ MIDDLEWARE = [
 ]
 
 DEFAULT_SETTINGS["MIDDLEWARE"] = MIDDLEWARE
-
-# DEV: Merge these settings into DEFAULT_SETTINGS when the minimum required
-#      Django version is 4.2 or higher
-if django.VERSION >= (4, 2):
-    DEFAULT_SETTINGS["STORAGES"] = {
-        "default": {
-            # Speeds up tests and prevents locally storing files created through them
-            "BACKEND": "django.core.files.storage.InMemoryStorage",
-        },
-    }
 
 
 def get_default_settings(*, database_name=DEFAULT_DATABASE_NAME):

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,7 @@ with open("README.rst") as readme, open("CHANGES.rst") as changes:
             "fallback_version": "0.0.0",
         },
         setup_requires=["setuptools_scm"],
-        # DEV: Remove `asgiref` when the minimum required Django version is 4.2
-        install_requires=["asgiref>=3.6"],
+        install_requires=[],
         description="Store model history and view/revert changes from admin site.",
         long_description="\n".join((readme.read(), changes.read())),
         long_description_content_type="text/x-rst",
@@ -38,7 +37,6 @@ with open("README.rst") as readme, open("CHANGES.rst") as changes:
             "Environment :: Web Environment",
             "Intended Audience :: Developers",
             "Framework :: Django",
-            "Framework :: Django :: 3.2",
             "Framework :: Django :: 4.2",
             "Framework :: Django :: 5.0",
             "Programming Language :: Python",

--- a/simple_history/tests/tests/test_admin.py
+++ b/simple_history/tests/tests/test_admin.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 from unittest.mock import ANY, patch
 
+import django
 from django.contrib.admin import AdminSite
 from django.contrib.admin.utils import quote
 from django.contrib.auth import get_user_model
@@ -621,6 +622,7 @@ class AdminSiteTest(TestCase):
         context = {
             **admin_site.each_context(request),
             # Verify this is set for original object
+            "log_entries": ANY,
             "original": poll,
             "change_history": False,
             "title": "Revert %s" % force_str(poll),
@@ -650,9 +652,9 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        # This key didn't exist prior to Django 4.2
-        if "log_entries" in context:
-            context["log_entries"] = ANY
+        # DEV: Remove this when support for Django 4.2 has been dropped
+        if django.VERSION < (5, 0):
+            del context["log_entries"]
 
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
@@ -680,6 +682,7 @@ class AdminSiteTest(TestCase):
         context = {
             **admin_site.each_context(request),
             # Verify this is set for history object not poll object
+            "log_entries": ANY,
             "original": history.instance,
             "change_history": True,
             "title": "Revert %s" % force_str(history.instance),
@@ -709,9 +712,9 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        # This key didn't exist prior to Django 4.2
-        if "log_entries" in context:
-            context["log_entries"] = ANY
+        # DEV: Remove this when support for Django 4.2 has been dropped
+        if django.VERSION < (5, 0):
+            del context["log_entries"]
 
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
@@ -739,6 +742,7 @@ class AdminSiteTest(TestCase):
         context = {
             **admin_site.each_context(request),
             # Verify this is set for history object not poll object
+            "log_entries": ANY,
             "original": poll,
             "change_history": False,
             "title": "Revert %s" % force_str(poll),
@@ -768,9 +772,9 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        # This key didn't exist prior to Django 4.2
-        if "log_entries" in context:
-            context["log_entries"] = ANY
+        # DEV: Remove this when support for Django 4.2 has been dropped
+        if django.VERSION < (5, 0):
+            del context["log_entries"]
 
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
@@ -798,6 +802,7 @@ class AdminSiteTest(TestCase):
         context = {
             **admin_site.each_context(request),
             # Verify this is set for history object
+            "log_entries": ANY,
             "original": history.instance,
             "change_history": True,
             "title": "Revert %s" % force_str(history.instance),
@@ -829,9 +834,9 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        # This key didn't exist prior to Django 4.2
-        if "log_entries" in context:
-            context["log_entries"] = ANY
+        # DEV: Remove this when support for Django 4.2 has been dropped
+        if django.VERSION < (5, 0):
+            del context["log_entries"]
 
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context
@@ -862,6 +867,7 @@ class AdminSiteTest(TestCase):
         context = {
             **admin_site.each_context(request),
             # Verify this is set for original object
+            "log_entries": ANY,
             "anything_else": "will be merged into context",
             "original": poll,
             "change_history": False,
@@ -892,9 +898,9 @@ class AdminSiteTest(TestCase):
             "save_on_top": admin.save_on_top,
             "root_path": getattr(admin_site, "root_path", None),
         }
-        # This key didn't exist prior to Django 4.2
-        if "log_entries" in context:
-            context["log_entries"] = ANY
+        # DEV: Remove this when support for Django 4.2 has been dropped
+        if django.VERSION < (5, 0):
+            del context["log_entries"]
 
         mock_render.assert_called_once_with(
             request, admin.object_history_form_template, context

--- a/simple_history/tests/tests/test_manager.py
+++ b/simple_history/tests/tests/test_manager.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from operator import attrgetter
 
-import django
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError
 from django.test import TestCase, override_settings, skipUnlessDBFeature
@@ -199,13 +198,6 @@ class BulkHistoryCreateTestCase(TestCase):
             Poll(id=4, question="Question 4", pub_date=datetime.now()),
         ]
 
-    # DEV: Remove this method when the minimum required Django version is 4.2
-    def assertQuerySetEqual(self, *args, **kwargs):
-        if django.VERSION < (4, 2):
-            return self.assertQuerysetEqual(*args, **kwargs)
-        else:
-            return super().assertQuerySetEqual(*args, **kwargs)
-
     def test_simple_bulk_history_create(self):
         created = Poll.history.bulk_history_create(self.data)
         self.assertEqual(len(created), 4)
@@ -333,13 +325,6 @@ class BulkHistoryUpdateTestCase(TestCase):
             Poll(id=3, question="Question 3", pub_date=datetime.now()),
             Poll(id=4, question="Question 4", pub_date=datetime.now()),
         ]
-
-    # DEV: Remove this method when the minimum required Django version is 4.2
-    def assertQuerySetEqual(self, *args, **kwargs):
-        if django.VERSION < (4, 2):
-            return self.assertQuerysetEqual(*args, **kwargs)
-        else:
-            return super().assertQuerySetEqual(*args, **kwargs)
 
     def test_simple_bulk_history_create(self):
         created = Poll.history.bulk_history_create(self.data, update=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist =
-    py{38,39,310}-dj32-{sqlite3,postgres,mysql,mariadb},
     py{38,39,310,311,312}-dj42-{sqlite3,postgres,mysql,mariadb},
     py{310,311,312}-dj50-{sqlite3,postgres,mysql,mariadb},
     py{310,311,312}-djmain-{sqlite3,postgres,mysql,mariadb},
     # DEV: Add `313` to the Python versions above (so that postgres is tested with 3.13)
-    #      when `psycopg2-binary` supports 3.13
+    #      when `psycopg` provides binaries for 3.13
     py313-dj{42,50,main}-{sqlite3,mysql,mariadb},
     docs,
     lint
@@ -21,7 +20,6 @@ python =
 
 [gh-actions:env]
 DJANGO =
-    3.2: dj32
     4.2: dj42
     5.0: dj50
     main: djmain
@@ -35,7 +33,6 @@ exclude = __init__.py,simple_history/registry_tests/migration_test_app/migration
 [testenv]
 deps =
     -rrequirements/test.txt
-    dj32: Django>=3.2,<3.3
     dj42: Django>=4.2,<4.3
     dj50: Django>=5.0,<5.1
     djmain: https://github.com/django/django/tarball/main


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Django 3.2's EOL was passed last month (April 1st); see [Django's supported versions](https://www.djangoproject.com/download/#supported-versions).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

None

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Removing support for dependencies for which development has stopped.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See the GitHub Actions test build.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
