### PR TITLE
Conditions addition to `insert_row` 

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -687,7 +687,6 @@ class HistoricalRecords:
             m2m_history_model = self.m2m_models[field]
             original_instance = history_instance.instance
             through_model = getattr(original_instance, field.name).through
-            through_model_field_names = [f.name for f in through_model._meta.fields]
             through_model_fk_field_names = [
                 f.name for f in through_model._meta.fields if isinstance(f, ForeignKey)
             ]
@@ -700,8 +699,14 @@ class HistoricalRecords:
             for row in rows:
                 insert_row = {"history": history_instance}
 
-                for field_name in through_model_field_names:
-                    insert_row[field_name] = getattr(row, field_name)
+                for through_model_field in through_model._meta.fields:
+                    # Remove any excluded kwargs for the field.
+                    if through_model_field.name not in self.field_excluded_kwargs(
+                        field
+                    ):
+                        insert_row[through_model_field.name] = getattr(
+                            row, through_model_field.name
+                        )
                 insert_rows.append(m2m_history_model(**insert_row))
 
             pre_create_historical_m2m_records.send(


### PR DESCRIPTION
Conditions the addition to `insert_row` within `create_historical_record_m2ms` in order to respect `excluded_field_kwargs` via `self.field_excluded_kwargs`.

This change necessarily undoes the addition of `through_model_field_names = [f.name for f in through_model._meta.fields]` which is not compatible with the api of `self.field_excluded_kwargs`.

<!--- Provide a general summary of your changes in the Title above -->

## Description
See #1358 

## Related Issue
#1358 

## Motivation and Context
#1358 

## How Has This Been Tested?
Yes, I run it in prod.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
