### PR TITLE
Improve performance of the latest_of_each method of the manager

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,6 +19,7 @@ Authors
 - Anton Kulikov (`bigtimecriminal <https://github.com/bigtimecriminal>`_)
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - Benjamin Mampaey (`bmampaey <https://github.com/bmampaey>`_)
+- Berke Agababaoglu (`bagababaoglu <https://github.com/bagababaoglu>`_)
 - Bheesham Persaud (`bheesham <https://github.com/bheesham>`_)
 - `bradford281 <https://github.com/bradford281>`_
 - Brian Armstrong (`barm <https://github.com/barm>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 
 - Made ``skip_history_when_saving`` work when creating an object - not just when
   updating an object (gh-1262)
+- Improve performance of the latest_of_each method of the manager
 
 3.7.0 (2024-05-29)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Unreleased
 
 - Made ``skip_history_when_saving`` work when creating an object - not just when
   updating an object (gh-1262)
-- Improve performance of the latest_of_each method of the manager
+- Improved performance of the ``latest_of_each()`` history manager method (gh-1360)
 
 3.7.0 (2024-05-29)
 ------------------

--- a/simple_history/tests/tests/test_manager.py
+++ b/simple_history/tests/tests/test_manager.py
@@ -12,7 +12,7 @@ from ..models import Choice, Document, Poll, RankedDocument
 User = get_user_model()
 
 
-class AsOfTest(TestCase):
+class AsOfTestCase(TestCase):
     model = Document
 
     def setUp(self):
@@ -69,7 +69,7 @@ class AsOfTest(TestCase):
         self.assertEqual(as_of_list[0].changed_by, self.obj.changed_by)
 
 
-class AsOfAdditionalTestCase(TestCase):
+class AsOfTestCaseWithoutSetUp(TestCase):
     def test_create_and_delete(self):
         document = Document.objects.create()
         now = datetime.now()
@@ -150,42 +150,57 @@ class AsOfAdditionalTestCase(TestCase):
         """
         Demonstrates how the HistoricalQuerySet works to provide as_of functionality.
         """
-        document1 = RankedDocument.objects.create(rank=42)
-        document2 = RankedDocument.objects.create(rank=84)
-        document2.rank = 51
+        document1 = RankedDocument.objects.create(rank=10)
+        document2 = RankedDocument.objects.create(rank=20)
+        document2.rank = 21
         document2.save()
         document1.delete()
+        t1 = datetime.now()
+        document3 = RankedDocument.objects.create(rank=30)  # noqa: F841
+        document2.rank = 22
+        document2.save()
         t2 = datetime.now()
 
-        # look for historical records, get back a queryset
+        # 4 records before `t1` (for document 1 and 2), 2 after (for document 2 and 3)
+        queryset = RankedDocument.history.filter(history_date__lte=t1)
+        self.assertEqual(queryset.count(), 4)
+        self.assertEqual(RankedDocument.history.filter(history_date__gt=t1).count(), 2)
+
+        # `latest_of_each()` returns the most recent record of each document
         with self.assertNumQueries(1):
-            queryset = RankedDocument.history.filter(history_date__lte=t2)
-            self.assertEqual(queryset.count(), 4)
+            self.assertEqual(queryset.latest_of_each().count(), 2)
 
-        # only want the most recend records (provided by HistoricalQuerySet)
-        self.assertEqual(queryset.latest_of_each().count(), 2)
+        # `as_instances()` returns the historical instances as of each record's time,
+        # but excludes deletion records (i.e. document 1's most recent record)
+        with self.assertNumQueries(1):
+            self.assertEqual(queryset.latest_of_each().as_instances().count(), 1)
 
-        # want to see the instances as of that time?
-        self.assertEqual(queryset.latest_of_each().as_instances().count(), 1)
+        # (Duplicate calls to these methods should not change the number of queries,
+        # since they're idempotent)
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                queryset.latest_of_each()
+                .latest_of_each()
+                .as_instances()
+                .as_instances()
+                .count(),
+                1,
+            )
 
-        # these new methods are idempotent
-        self.assertEqual(
-            queryset.latest_of_each()
-            .latest_of_each()
-            .as_instances()
-            .as_instances()
-            .count(),
-            1,
-        )
-
-        # that was all the same as calling as_of!
-        self.assertEqual(
+        self.assertSetEqual(
+            # In conclusion, all of these methods combined...
             set(
-                RankedDocument.history.filter(history_date__lte=t2)
+                RankedDocument.history.filter(history_date__lte=t1)
                 .latest_of_each()
                 .as_instances()
             ),
-            set(RankedDocument.history.as_of(t2)),
+            # ...are equivalent to calling `as_of()`!
+            set(RankedDocument.history.as_of(t1)),
+        )
+
+        self.assertEqual(RankedDocument.history.as_of(t1).get().rank, 21)
+        self.assertListEqual(
+            [d.rank for d in RankedDocument.history.as_of(t2)], [22, 30]
         )
 
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -30,11 +30,6 @@ from simple_history.signals import (
     pre_create_historical_m2m_records,
     pre_create_historical_record,
 )
-from simple_history.tests.tests.utils import (
-    database_router_override_settings,
-    database_router_override_settings_history_in_diff_db,
-    middleware_override_settings,
-)
 from simple_history.utils import get_history_model_for_model, update_change_reason
 
 from ..external.models import (
@@ -126,6 +121,12 @@ from ..models import (
     UUIDModel,
     WaterLevel,
 )
+from .utils import (
+    HistoricalTestCase,
+    database_router_override_settings,
+    database_router_override_settings_history_in_diff_db,
+    middleware_override_settings,
+)
 
 get_model = apps.get_model
 User = get_user_model()
@@ -140,17 +141,9 @@ def get_fake_file(filename):
     return fake_file
 
 
-class HistoricalRecordsTest(TestCase):
+class HistoricalRecordsTest(HistoricalTestCase):
     def assertDatetimesEqual(self, time1, time2):
         self.assertAlmostEqual(time1, time2, delta=timedelta(seconds=2))
-
-    def assertRecordValues(self, record, klass, values_dict):
-        for key, value in values_dict.items():
-            self.assertEqual(getattr(record, key), value)
-        self.assertEqual(record.history_object.__class__, klass)
-        for key, value in values_dict.items():
-            if key not in ["history_type", "history_change_reason"]:
-                self.assertEqual(getattr(record.history_object, key), value)
 
     def test_create(self):
         p = Poll(question="what's up?", pub_date=today)

--- a/simple_history/tests/tests/utils.py
+++ b/simple_history/tests/tests/utils.py
@@ -1,9 +1,9 @@
 from enum import Enum
+from typing import Type
 
-import django
 from django.conf import settings
-
-from simple_history.tests.models import HistoricalModelWithHistoryInDifferentDb
+from django.db.models import Model
+from django.test import TestCase
 
 request_middleware = "simple_history.middleware.HistoryRequestMiddleware"
 
@@ -12,6 +12,27 @@ OTHER_DB_NAME = "other"
 middleware_override_settings = {
     "MIDDLEWARE": (settings.MIDDLEWARE + [request_middleware])
 }
+
+
+class HistoricalTestCase(TestCase):
+    def assertRecordValues(self, record, klass: Type[Model], values_dict: dict):
+        """
+        Fail if ``record`` doesn't contain the field values in ``values_dict``.
+        ``record.history_object`` is also checked.
+        History-tracked fields in ``record`` that are not in ``values_dict``, are not
+        checked.
+
+        :param record: A historical record.
+        :param klass: The type of the history-tracked class of ``record``.
+        :param values_dict: Field names of ``record`` mapped to their expected values.
+        """
+        for key, value in values_dict.items():
+            self.assertEqual(getattr(record, key), value)
+
+        self.assertEqual(record.history_object.__class__, klass)
+        for key, value in values_dict.items():
+            if key not in ("history_type", "history_change_reason"):
+                self.assertEqual(getattr(record.history_object, key), value)
 
 
 class TestDbRouter:
@@ -46,16 +67,25 @@ database_router_override_settings = {
 
 class TestModelWithHistoryInDifferentDbRouter:
     def db_for_read(self, model, **hints):
+        # Avoids circular importing
+        from ..models import HistoricalModelWithHistoryInDifferentDb
+
         if model == HistoricalModelWithHistoryInDifferentDb:
             return OTHER_DB_NAME
         return None
 
     def db_for_write(self, model, **hints):
+        # Avoids circular importing
+        from ..models import HistoricalModelWithHistoryInDifferentDb
+
         if model == HistoricalModelWithHistoryInDifferentDb:
             return OTHER_DB_NAME
         return None
 
     def allow_relation(self, obj1, obj2, **hints):
+        # Avoids circular importing
+        from ..models import HistoricalModelWithHistoryInDifferentDb
+
         if isinstance(obj1, HistoricalModelWithHistoryInDifferentDb) or isinstance(
             obj2, HistoricalModelWithHistoryInDifferentDb
         ):
@@ -63,6 +93,9 @@ class TestModelWithHistoryInDifferentDbRouter:
         return None
 
     def allow_migrate(self, db, app_label, model_name=None, **hints):
+        # Avoids circular importing
+        from ..models import HistoricalModelWithHistoryInDifferentDb
+
         if model_name == HistoricalModelWithHistoryInDifferentDb._meta.model_name:
             return db == OTHER_DB_NAME
         return None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`latest_of_each` method of the manager is currently getting all the latest `pks` and using a `pk__in` filter to determine final results. But `in` filter is performing bad, especially when there are a lot of rows in the db. Every item in the database needs to be compared by this long list.  This can be avoided by using another subquery which would annotate the existence of later items and then it can be used to filter the query by this field to get latest of each item. 

This also removes the need to have database specific implementation as the resulting query should work on each.  

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Currently there are no related issues. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Improves performance for `latest_of_each` method which is necessary for history tables which are having a lot of data. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests for the method has been used. 

Results from query analysis which ran on postgresql. The table 1.8 million entries. 

This is the cost analysis for the improved query 
```
Limit  (cost=130063.36..131511.02 rows=50 width=5438) (actual time=327.427..343.020 rows=50 loops=1)
```

This is the cost analysis for the normal query 
```
Limit  (cost=483323.35..483323.47 rows=50 width=5438) (actual time=2142.676..2148.425 rows=50 loops=1)
```

According to these results, there is %84,7338936 improvement. 


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Improvement 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [X] All new and existing tests passed.
