### PR TITLE
Fixes #527 history button not working

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -146,6 +146,7 @@ Authors
 - `DanialErfanian <https://github.com/DanialErfanian>`_
 - `Sridhar Marella <https://github.com/sridhar562345>`_
 - `Mattia Fantoni <https://github.com/MattFanto>`_
+- `Trent Holliday <https://github.com/trumpet2012>`_
 
 Background
 ==========

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
 - Dropped support for Python 3.8, which reached end-of-life on 2024-10-07 (gh-1421)
 - Added support for Django 5.1 (gh-1388)
 - Added pagination to ``SimpleHistoryAdmin`` (gh-1277)
+- Fixed issue with history button not working when viewing historical entries in the
+  admin (gh-527)
 
 3.7.0 (2024-05-29)
 ------------------

--- a/simple_history/templates/simple_history/object_history_form.html
+++ b/simple_history/templates/simple_history/object_history_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n %}
+{% load i18n admin_urls %}
 {% load url from simple_history_compat %}
 
 {% block breadcrumbs %}
@@ -19,6 +19,14 @@
 
 {% block submit_buttons_bottom %}
   {% include "simple_history/submit_line.html" %}
+{% endblock %}
+
+{% block object-tools-items %}
+{# We override this block from the django template to fix up the history link #}
+<li>
+    <a href="{% add_preserved_filters history_url %}" class="historylink">{% translate "History" %}</a>
+</li>
+{% if has_absolute_url %}<li><a href="{{ absolute_url }}" class="viewsitelink">{% translate "View on site" %}</a></li>{% endif %}
 {% endblock %}
 
 {% block form_top %}


### PR DESCRIPTION
## Description
This PR fixes the history button that gets shown when viewing a historical version of a model so that it correctly links back to the history listing for that object.

## Related Issue
#527 

## Motivation and Context
Fixes a broken link that users expect to work.

## How Has This Been Tested?
I tested this by installing it as a development dependency in our django project. I also ran `make tests` however only the sqlite versions worked since I haven't setup postgres/msql locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
