### PR TITLE
fixes #1362: incorrect rendering of history change form if has_change_permission == False

### DIFF
--- a/simple_history/admin.py
+++ b/simple_history/admin.py
@@ -5,7 +5,7 @@ from django.apps import apps as django_apps
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import helpers
-from django.contrib.admin.utils import unquote
+from django.contrib.admin.utils import flatten_fieldsets, unquote
 from django.contrib.auth import get_permission_codename, get_user_model
 from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
@@ -20,6 +20,7 @@ from .manager import HistoricalQuerySet, HistoryManager
 from .models import HistoricalChanges
 from .template_utils import HistoricalRecordContextHelper
 from .utils import get_history_manager_for_model, get_history_model_for_model
+
 
 SIMPLE_HISTORY_EDIT = getattr(settings, "SIMPLE_HISTORY_EDIT", False)
 
@@ -240,11 +241,18 @@ class SimpleHistoryAdmin(admin.ModelAdmin):
         else:
             form = form_class(instance=obj)
 
+        fieldsets = self.get_fieldsets(request, obj)
+
+        if object_id and not self.has_change_permission(request, obj):
+            readonly_fields = flatten_fieldsets(fieldsets)
+        else:
+            readonly_fields = self.get_readonly_fields(request, obj)
+
         admin_form = helpers.AdminForm(
             form,
-            self.get_fieldsets(request, obj),
+            fieldsets,
             self.prepopulated_fields,
-            self.get_readonly_fields(request, obj),
+            readonly_fields,
             model_admin=self,
         )
 


### PR DESCRIPTION
Rendering behaviour of history change_form isn't as expected if `has_change_permission == False`.

## Description

django Admin renders a "form" full of readonly_fields in this case:

```python

@admin.register(Foo)
class FooAdmin(SimpleHistoryAdmin):
    # ...

    def has_change_permission(self, request, obj=None):
        return False
```

Instead of rendering like the original change_form of `Foo` (just readonly fields), it renders form fields. But no submit buttons.

djangos `ModelAdmin` adds all fields to `ModelAdmin.readonly_fields`.

This behaviour has been copied `ModelAdmin._changeform_view` to `SimpleHIstoryAdmin.history_form_view`.

## Related Issue

An Issue for this already exists: #1360

## Motivation and Context

Getting SimpleHistoryModel to act as expected, which is to be consistent with djangos ModelAdmin.

## How Has This Been Tested?

Comparing of SimpleHistoryModel behaviour with corresponding ModelAdmin and default django-simple-history settings.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
