### PR TITLE
Fixed reason field being shared between models.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -111,6 +111,7 @@ Authors
 - Nathan Villagaray-Carski (`ncvc <https://github.com/ncvc>`_)
 - Nianpeng Li
 - Nick Träger
+- Noam Kushinsky (`noamkush <https://github.com/noamkush>`_)
 - Noel James (`NoelJames <https://github.com/NoelJames>`_)
 - Ofek Lev (`ofek <https://github.com/ofek>`_)
 - Phillip Marshall

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Unreleased
 - Added pagination to ``SimpleHistoryAdmin`` (gh-1277)
 - Fixed issue with history button not working when viewing historical entries in the
   admin (gh-527)
+- Fixed history_change_reason_field being shared across inherited models (gh-1433)
 
 3.7.0 (2024-05-29)
 ------------------

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -411,7 +411,7 @@ class HistoricalRecords:
     def _get_history_change_reason_field(self):
         if self.history_change_reason_field:
             # User specific field from init
-            history_change_reason_field = self.history_change_reason_field
+            history_change_reason_field = self.history_change_reason_field.clone()
         elif getattr(
             settings, "SIMPLE_HISTORY_HISTORY_CHANGE_REASON_USE_TEXT_FIELD", False
         ):

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -650,6 +650,12 @@ class TrackedAbstractBaseB(models.Model):
         abstract = True
 
 
+class TrackedAbstractBaseWithReasonField(models.Model):
+    history = HistoricalRecords(
+        inherit=True, history_change_reason_field=models.TextField()
+    )
+
+
 class UntrackedAbstractBase(models.Model):
     class Meta:
         abstract = True
@@ -706,6 +712,14 @@ class InheritTracking3(BaseInheritTracking3):
 
 
 class InheritTracking4(TrackedAbstractBaseA):
+    pass
+
+
+class InheritReasonField1(TrackedAbstractBaseWithReasonField):
+    pass
+
+
+class InheritReasonField2(TrackedAbstractBaseWithReasonField):
     pass
 
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -71,6 +71,8 @@ from ..models import (
     HistoricalPollWithManyToMany_places,
     HistoricalState,
     InheritedRestaurant,
+    InheritReasonField1,
+    InheritReasonField2,
     Library,
     ManyToManyModelOther,
     ModelWithCustomAttrOneToOneField,
@@ -685,6 +687,29 @@ class HistoricalRecordsTest(HistoricalTestCase):
 
         self.assertTrue(isinstance(field, models.TextField))
         self.assertEqual(history.history_change_reason, reason)
+
+    def test_inherited_history_change_reason_update(self):
+        inherited1 = InheritReasonField1.history.create(
+            history_change_reason="reason1", id=1, history_date=datetime.now()
+        )
+        inherited2 = InheritReasonField2.history.create(
+            history_change_reason="reason2", id=1, history_date=datetime.now()
+        )
+
+        InheritReasonField1.history.update(history_change_reason="new_reason1")
+        InheritReasonField2.history.update(history_change_reason="new_reason2")
+
+        inherited1.refresh_from_db()
+        inherited2.refresh_from_db()
+
+        self.assertEqual(inherited1.history_change_reason, "new_reason1")
+        self.assertEqual(inherited2.history_change_reason, "new_reason2")
+
+    def test_history_change_reason_field_not_shared(self):
+        self.assertIsNot(
+            InheritReasonField1.history.model._meta.get_field("history_change_reason"),
+            InheritReasonField2.history.model._meta.get_field("history_change_reason"),
+        )
 
     def test_history_diff_includes_changed_fields(self):
         p = Poll.objects.create(question="what's up?", pub_date=today)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the custom reason field being shared between inherited models. It causes issues when calling `update()` on the historical model. When generating the field, a `clone()` call is added so the field wouldn't be shared.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #1433 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests reproducing the issue. The tests fail on master branch.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
