### PR TITLE
Use tuple for m2m_models

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -97,6 +97,7 @@ Authors
 - Marcelo Canina (`marcanuy <https://github.com/marcanuy>`_)
 - Marco Sirabella
 - Mark Davidoff
+- Marti Markov (`martimarkov <https://github.com/martimarkov>`_)
 - Martin Bachwerk
 - Marty Alchin
 - Matheus Cansian (`mscansian <https://github.com/mscansian>`_)

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -245,7 +245,7 @@ class HistoricalRecords:
             m2m_model = self.create_history_m2m_model(
                 history_model, field.remote_field.through
             )
-            self.m2m_models[field] = m2m_model
+            self.m2m_models[(sender._meta.object_name, field)] = m2m_model
 
             setattr(module, m2m_model.__name__, m2m_model)
 
@@ -706,7 +706,7 @@ class HistoricalRecords:
 
     def create_historical_record_m2ms(self, history_instance, instance):
         for field in history_instance._history_m2m_fields:
-            m2m_history_model = self.m2m_models[field]
+            m2m_history_model = self.m2m_models[(instance._meta.object_name, field)]
             original_instance = history_instance.instance
             through_model = getattr(original_instance, field.name).through
             through_model_field_names = [f.name for f in through_model._meta.fields]


### PR DESCRIPTION
Changes how the `m2m_models` is defined. 

## Description
Uses a tuple containing the object name and the field. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/jazzband/django-simple-history/issues/1435


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensures that there are no clashes when the m2m relationship is in a parent model and there are multiple child models. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all the tests in the suite and no issues came up. 


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
