### PR TITLE
Update models.py to retrieve app_label from model meta if no app is specified

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -644,8 +644,7 @@ class HistoricalRecords:
             )
         meta_fields["verbose_name"] = name
         meta_fields["verbose_name_plural"] = plural_name
-        if self.app:
-            meta_fields["app_label"] = self.app
+        meta_fields["app_label"] = self.app if self.app else model._meta.app_label
         if self._date_indexing == "composite":
             meta_fields["indexes"] = (
                 models.Index(fields=("history_date", model._meta.pk.attname)),


### PR DESCRIPTION
Retrieve app_label from model meta if no app is specified

`meta_fields["app_label"] = self.app if self.app else model._meta.app_label`

replaces
```
if self.app:
     meta_fields["app_label"] = self.app
```

To ensure that the simple history model always has an app_label

## Motivation and Context
I ran into this issue when developing an app for django that had an extra service that could integrate with any app, my service adds models into the app, and the models' histories are tracked using django simple history. Django threw the  `Model class doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS.` which prompted me to go down this road.

## How Has This Been Tested?
This has only been tested in so far as it adds an app_label to models outside of an installed app. No official tests have been written.

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
