### PR TITLE
Exclude tests from wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ core-metadata-version = "2.2"
 packages = [
   "simple_history",
 ]
+exclude = [
+  "simple_history/registry_tests",
+  "simple_history/tests",
+]
 
 [tool.hatch.build.targets.sdist]
 # Jazzband's release process is limited to 2.2 metadata


### PR DESCRIPTION
## Description

The wheels currently bundle all tests, which just bloats them and usually is of no value for the actual library usage.

## Related Issue

Closes #1477.

## Motivation and Context

Bundling tests inside wheels is uncommon and just increases the distribution size.

## How Has This Been Tested?

Built the package locally using `PIP_INDEX_URL=https://pypi.org/simple python -m build .` and verified manually that the generated source distribution and wheel file have the expected directories.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
