### PR TITLE
Enable UUIDv7

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,6 +19,7 @@ Authors
 - Anton Kulikov (`bigtimecriminal <https://github.com/bigtimecriminal>`_)
 - Ben Lawson (`blawson <https://github.com/blawson>`_)
 - Benjamin Mampaey (`bmampaey <https://github.com/bmampaey>`_)
+- Benjamin Skov Kaas-Hansen (`epiben <https://github.com/epiben>`_)
 - Berke Agababaoglu (`bagababaoglu <https://github.com/bagababaoglu>`_)
 - Bheesham Persaud (`bheesham <https://github.com/bheesham>`_)
 - `bradford281 <https://github.com/bradford281>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,10 +43,10 @@ Authors
 - David Smith
 - `ddabble <https://github.com/ddabble>`_
 - Dmytro Shyshov (`xahgmah <https://github.com/xahgmah>`_)
-- Edouard Richard (`vied12 <https://github.com/vied12>` _)
+- Edouard Richard (`vied12 <https://github.com/vied12>`_)
 - Eduardo Cuducos
 - Erik van Widenfelt (`erikvw <https://github.com/erikvw>`_)
-- Fábio Capuano (`fabiocapsouza <https://github.com/fabiocapsouza`_)
+- Fábio Capuano (`fabiocapsouza <https://github.com/fabiocapsouza>`_)
 - Filipe Pina (@fopina)
 - Florian Eßer
 - François Martin (`martinfrancois <https://github.com/martinfrancois>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 
 - Added support for Python 3.14
 - Added support for Django 6.0
+- Added UUIDv7 support for ``history_id`` fields (gh-1532)
 
 3.10.1 (2025-06-20)
 -------------------

--- a/docs/historical_model.rst
+++ b/docs/historical_model.rst
@@ -27,13 +27,15 @@ The example below uses a ``UUIDField`` instead of an ``AutoField``:
 
 Since using a ``UUIDField`` for the ``history_id`` is a common use case, there is a
 ``SIMPLE_HISTORY_HISTORY_ID_USE_UUID`` setting that will set all instances of ``history_id`` to UUIDs.
+By default, this will use UUIDv4, but you can choose to use UUIDv7 by setting
+``SIMPLE_HISTORY_HISTORY_ID_UUID_VERSION`` to ``7``.
 Set this with the following line in your ``settings.py`` file:
 
 
 .. code-block:: python
 
     SIMPLE_HISTORY_HISTORY_ID_USE_UUID = True
-
+    SIMPLE_HISTORY_HISTORY_ID_UUID_VERSION = 7  # Optional
 
 
 This setting can still be overridden using the ``history_id_field`` parameter on a per model basis.

--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -429,8 +429,19 @@ class HistoricalRecords:
             history_id_field.primary_key = True
             history_id_field.editable = False
         elif getattr(settings, "SIMPLE_HISTORY_HISTORY_ID_USE_UUID", False):
+            uuid_version = getattr(
+                settings, "SIMPLE_HISTORY_HISTORY_ID_UUID_VERSION", 4
+            )
+            if uuid_version == 4:
+                uuid_default = uuid.uuid4
+            elif uuid_version == 7:
+                uuid_default = utils.uuid7
+            else:
+                raise ImproperlyConfigured(
+                    "SIMPLE_HISTORY_HISTORY_ID_UUID_VERSION must be either 4 or 7"
+                )
             history_id_field = models.UUIDField(
-                primary_key=True, default=uuid.uuid4, editable=False
+                primary_key=True, default=uuid_default, editable=False
             )
         else:
             history_id_field = models.AutoField(primary_key=True)

--- a/simple_history/tests/models.py
+++ b/simple_history/tests/models.py
@@ -797,6 +797,18 @@ class UUIDDefaultModel(models.Model):
     history = HistoricalRecords()
 
 
+# Set the SIMPLE_HISTORY_HISTORY_ID_UUID_VERSION
+setattr(settings, "SIMPLE_HISTORY_HISTORY_ID_UUID_VERSION", 7)
+
+
+class UUIDv7Model(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    history = HistoricalRecords()
+
+
+# Clear the SIMPLE_HISTORY_HISTORY_ID_UUID_VERSION
+delattr(settings, "SIMPLE_HISTORY_HISTORY_ID_UUID_VERSION")
+
 # Clear the SIMPLE_HISTORY_HISTORY_ID_USE_UUID
 delattr(settings, "SIMPLE_HISTORY_HISTORY_ID_USE_UUID")
 


### PR DESCRIPTION
## Description
With this PR, users can choose between UUIDv4 and UUIDv7 for their PKs.

## Related Issue
This PR implements the request made in #1532.

## Motivation and Context
Using UUIDv7 yields faster I/O because they're sortable and, thus, friendlier to database indices. Being sortable, it's also possible to show the chronological order of historical records when these are created with below-minute resolution (the lowest allowed by `history_date`) or when multiple records are set to have the same `history_date` but with a meaningful order of insertion.

The implementation is non-breaking in that it adds a new settings for specifying the UUID version, falling back to UUIDv4 (the currently only option) if unspecified.

## How Has This Been Tested?
With the full test suite. The MySQL tests couldn't even run on my machine, so I'd be happy for some help to make that work locally if required.

## Screenshots (if appropriate):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have run the `pre-commit run` command to format and lint.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] I have added my name and/or github handle to `AUTHORS.rst`
- [x] I have added my change to `CHANGES.rst`
- [x] All new and existing tests passed.
