### PR TITLE
fix: catch correct DoesNotExist in HistoricReverseOneToOneDescriptor.…

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -980,6 +980,34 @@ class HistoricReverseOneToOneDescriptor(
     def get_related_model(self):
         return self.related.related_model
 
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            return self
+
+        try:
+            rel_obj = self.related.get_cached_value(instance)
+        except KeyError:
+            if instance.pk is None:
+                rel_obj = None
+            else:
+                filter_args = self.related.field.get_forward_related_filter(instance)
+                queryset = self.get_queryset(instance=instance)
+                try:
+                    rel_obj = queryset.get(**filter_args)
+                except queryset.model.DoesNotExist:
+                    rel_obj = None
+                else:
+                    self.related.field.set_cached_value(rel_obj, instance)
+            self.related.set_cached_value(instance, rel_obj)
+
+        if rel_obj is None:
+            raise self.RelatedObjectDoesNotExist(
+                "%s has no %s."
+                % (instance.__class__.__name__, self.related.accessor_name)
+            )
+        else:
+            return rel_obj
+
 
 class HistoricOneToOneField(models.OneToOneField):
     """

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -2985,3 +2985,19 @@ class HistoricOneToOneFieldTest(TestCase):
         )
         pt1i = pt1h.instance
         self.assertEqual(pt1i.organization.name, "original")
+
+    def test_hasattr_missing_reverse_onetoone_does_not_raise(self):
+        """
+        Regression test for https://github.com/django-commons/django-simple-history/issues/1588
+
+        When a HistoricOneToOneField reverse relation does not exist,
+        hasattr() should return False instead of raising DoesNotExist.
+        """
+        org = TestOrganizationWithHistory.objects.create(name="lonely_org")
+        t1 = timezone.now()
+        # No participant created — reverse OneToOne is missing
+        historic_org = TestOrganizationWithHistory.history.as_of(t1).get(
+            name="lonely_org"
+        )
+        # Before the fix this raised HistoricalTestHistoricParticipanToHistoricOrganizationOneToOne.DoesNotExist
+        self.assertFalse(hasattr(historic_org, "historic_participant"))


### PR DESCRIPTION

Closes #1588

Django's ReverseOneToOneDescriptor.__get__ catches self.related.related_model.DoesNotExist, but when HistoricDescriptorMixin.get_queryset() returns a queryset over the historical model (e.g. HistoricalB instead of B), only the historical model's DoesNotExist matches. Override __get__ in HistoricReverseOneToOneDescriptor to catch queryset.model.DoesNotExist so that hasattr/getattr on a missing reverse OneToOne returns False/None instead of raising.

Adds a regression test to HistoricOneToOneFieldTest covering the missing-relation case.

```
from onkol.apps.users.models import A
from django.utils.timezone import now

# Create object
a = A.objects.create()

# Get historical version at current time
historic_a = a.history.as_of(now())

# Assertions
assert not hasattr(a, 'b')
assert not hasattr(historic_a, 'b')
```


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have run the `pre-commit run` command to format and lint.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] I have added my name and/or github handle to `AUTHORS.rst`
- [ ] I have added my change to `CHANGES.rst`
- [ ] All new and existing tests passed.
