### PR TITLE
Fix issue #341: Warn when using HistoricalRecords on an abstract c

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Addressing good-first-issue #341: Warn when using HistoricalRecords on an abstract class without inherit=True


### PR DESCRIPTION
Fixes good-first-issue #341