### PR TITLE
Fix #1582: Include custom base model fields in diff_against()

### DIFF
--- a/simple_history/models.py
+++ b/simple_history/models.py
@@ -1065,6 +1065,26 @@ class HistoricalChanges(ModelTypeHint):
         included_m2m_fields = {field.name for field in old_history._history_m2m_fields}
         if included_fields is None:
             included_fields = {f.name for f in old_history.tracked_fields if f.editable}
+            # Also include any extra fields added by custom base classes
+            # (passed via the `bases` parameter of `HistoricalRecords`).
+            # These fields exist on the historical model but not in
+            # `tracked_fields`, which only contains the original model's fields.
+            history_internal_fields = {
+                "history_id",
+                "history_date",
+                "history_change_reason",
+                "history_type",
+                "history_user",
+                "history_relation",
+            }
+            tracked_field_names = {f.name for f in old_history.tracked_fields}
+            for f in old_history._meta.fields:
+                if (
+                    f.editable
+                    and f.name not in history_internal_fields
+                    and f.name not in tracked_field_names
+                ):
+                    included_fields.add(f.name)
         else:
             included_m2m_fields = included_m2m_fields.intersection(included_fields)
 

--- a/simple_history/tests/tests/test_models.py
+++ b/simple_history/tests/tests/test_models.py
@@ -94,6 +94,7 @@ from ..models import (
     PollWithExcludedFKField,
     PollWithExcludeFields,
     PollWithHistoricalIPAddress,
+    PollWithHistoricalSessionAttr,
     PollWithManyToMany,
     PollWithManyToManyCustomHistoryID,
     PollWithManyToManyWithIPAddress,
@@ -932,6 +933,31 @@ class HistoricalRecordsTest(HistoricalTestCase):
             new_record,
         )
         self.assertEqual(delta, expected_delta)
+
+    def test_history_diff_includes_custom_base_fields(self):
+        """Fields added via a custom base class (the `bases` parameter) should
+        be included in `diff_against()` results.  Regression test for #1582."""
+        p = PollWithHistoricalSessionAttr.objects.create(question="what's up?")
+        p.question = "what's up, bro?"
+        p.save()
+        new_record, old_record = p.history.all()
+
+        # Manually set different values for the custom base field
+        old_record.session = "session-old"
+        old_record.save()
+        new_record.session = "session-new"
+        new_record.save()
+
+        delta = new_record.diff_against(old_record)
+        changed_field_names = delta.changed_fields
+        # The 'session' field from the custom base should appear in the diff
+        self.assertIn("session", changed_field_names)
+        # The tracked model field change should also still appear
+        self.assertIn("question", changed_field_names)
+
+        session_change = next(c for c in delta.changes if c.field == "session")
+        self.assertEqual(session_change.old, "session-old")
+        self.assertEqual(session_change.new, "session-new")
 
     def test_history_with_unknown_field(self):
         p = Poll.objects.create(question="what's up?", pub_date=today)


### PR DESCRIPTION
# [Improvement] – Include custom base model fields in `diff_against()` deltas

## Description

**Context:**
Previously, fields added via a custom base class (passed using the `bases` parameter of `HistoricalRecords`) were excluded from the results of `diff_against()`. This happened because `diff_against()` used `tracked_fields` as its default set of included fields, and `tracked_fields` is explicitly designed by the library to only include the fields present on the original model. As a result, custom base fields (like custom session tracking or IP address tracking columns) would silently be omitted from history diffs, even when their values clearly changed between versions (Issue #1582).

**Approach:**
- Modified the default `included_fields` logic within `HistoricalChanges.diff_against()` in `simple_history/models.py`.
- Instead of strictly falling back to `tracked_fields`, the method now cleanly scans the historical model's `_meta.fields` for any editable fields that are not already tracked and are not internal history metadata (e.g., `history_id`, `history_date`, `history_type`, etc.).
- Added a targeted regression test (`test_history_diff_includes_custom_base_fields`) in `simple_history/tests/tests/test_models.py` leveraging the existing `PollWithHistoricalSessionAttr` test model.

**Impact:**
- **Functionality**: `diff_against()` now correctly identifies and includes changes to custom base fields (e.g., `session` or `ip_address` fields added via `bases`) in its returned `ModelDelta` objects.
- **Developer Experience**: Resolves a confusing pain point where custom tracked fields were successfully stored in the database but wouldn't appear in diff comparisons. 
- **Robustness**: The fix strictly avoids modifying the generic `tracked_fields` definition, ensuring that other features reliant on `tracked_fields` (like `most_recent()` and `bulk_history_create()`) remain completely unaffected and safe.

## Visual Proof / Evidence

The entire test suite ran successfully, including the new regression test, proving the fix works precisely as intended and maintains full backwards compatibility with all existing diff behaviors.

<img width="1366" height="374" alt="image" src="https://github.com/user-attachments/assets/a1335a41-9033-4b9f-be86-fb34b7b2b365" />


## Tests
- [x] New tests added
- [ ] Existing tests updated or refactored

**Unit Tests Summary:**
- Added `test_history_diff_includes_custom_base_fields` in `simple_history/tests/tests/test_models.py`: Leverages the `PollWithHistoricalSessionAttr` model to create snapshots with different custom field values (`session-old` and `session-new`). Calling `diff_against()` asserts that the `session` field name safely populates into `delta.changed_fields`, and validates that its old and new values correctly appear inside `delta.changes`.
