### PR TITLE
Fix ValueError in clean_duplicate_history when using iterator() after prefetch_related()

### DIFF
--- a/simple_history/management/commands/clean_duplicate_history.py
+++ b/simple_history/management/commands/clean_duplicate_history.py
@@ -93,7 +93,7 @@ class Command(populate_history.Command):
                     pk__in=(m_qs.values_list(model._meta.pk.name).distinct())
                 )
 
-            for o in model_query.iterator():
+            for o in model_query.iterator(chunk_size=2000):
                 self._process_instance(o, model, stop_date=stop_date, dry_run=dry_run)
 
     def _process_instance(self, instance, model, stop_date=None, dry_run=True):


### PR DESCRIPTION
## Problem

Closes #1480

In Django 5.0+, calling `.iterator()` without a `chunk_size` argument raises a `ValueError` when the queryset has had `prefetch_related()` set up on it:

```
ValueError: chunk_size must be provided when using QuerySet.iterator() after prefetch_related()
```

This causes the `clean_duplicate_history` management command to crash.

## Fix

Add `chunk_size=2000` to the `.iterator()` call in `clean_duplicate_history.py`. This matches the maintainer's recommended solution in the issue thread.

```python
# Before
for o in model_query.iterator():

# After
for o in model_query.iterator(chunk_size=2000):
```
